### PR TITLE
Add Mordheim roster web app with dark fantasy theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
 # MeatHammerMordHeim
+
+Mordheim warband roster manager — a browser-based web app for creating, equipping, and tracking your Mordheim warbands through a campaign.
+
+## Features
+
+- Create rosters for all core Mordheim warbands (Reikland, Middenheim, Marienburg, Witch Hunters, Sisters of Sigmar, Undead, Cult of the Possessed, Skaven)
+- Recruit heroes and henchmen with full stat lines
+- Equip warriors from the equipment lists (weapons, armour, miscellaneous gear)
+- Assign skills from each hero's available skill categories
+- Track experience, levels, and advancement
+- Record injuries and stat modifications
+- Manage treasury (gold crowns and wyrdstone)
+- Log battles and campaign notes
+- Export/import rosters as JSON files
+- All data persisted in browser localStorage
+
+## Data Files
+
+Game data is stored in structured JSON files under `data/` for easy editing:
+
+| File | Contents |
+|------|----------|
+| `data/warbands.json` | Warband types, hero/henchman templates, stat lines, skill access |
+| `data/equipment.json` | Weapons, armour, and miscellaneous equipment with costs and rules |
+| `data/skills.json` | Skill categories (Combat, Shooting, Academic, Strength, Speed) |
+| `data/injuries.json` | Hero and henchman injury tables |
+| `data/advancement.json` | Experience thresholds, advancement rolls, max stat values |
+
+## Running
+
+Serve the project directory with any static HTTP server:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then open `http://localhost:8000` in your browser.
+
+## Tech Stack
+
+Plain HTML, CSS, and JavaScript — no build tools or dependencies required.

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,1022 @@
+/* ===== MORDHEIM ROSTER APP - DARK FANTASY THEME ===== */
+
+:root {
+  --bg-darkest: #0a0a0f;
+  --bg-dark: #12121c;
+  --bg-card: #1a1a2e;
+  --bg-card-hover: #1f1f35;
+  --bg-input: #15152a;
+  --border: #2a2a4a;
+  --border-hover: #3d3d6b;
+  --accent: #c9a84c;
+  --accent-hover: #dbb94f;
+  --accent-dim: #8a6d2b;
+  --accent-glow: rgba(201, 168, 76, 0.15);
+  --danger: #b33a3a;
+  --danger-hover: #d04444;
+  --success: #3a8a3a;
+  --success-hover: #44a544;
+  --text: #e8e6e3;
+  --text-dim: #9998a5;
+  --text-muted: #5d5c6d;
+  --text-bright: #f5f3f0;
+  --skull: #c9a84c;
+  --shadow: rgba(0, 0, 0, 0.5);
+  --radius: 6px;
+  --radius-lg: 10px;
+  --transition: 0.2s ease;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 15px;
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  background: var(--bg-darkest);
+  color: var(--text);
+  min-height: 100vh;
+  line-height: 1.5;
+}
+
+/* ===== SCROLLBAR ===== */
+::-webkit-scrollbar { width: 8px; }
+::-webkit-scrollbar-track { background: var(--bg-dark); }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: var(--border-hover); }
+
+/* ===== HEADER ===== */
+.app-header {
+  background: linear-gradient(180deg, var(--bg-card) 0%, var(--bg-dark) 100%);
+  border-bottom: 1px solid var(--border);
+  padding: 1rem 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-shadow: 0 2px 20px var(--shadow);
+}
+
+.app-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.app-title .skull-icon {
+  font-size: 1.3rem;
+}
+
+.header-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+/* ===== BUTTONS ===== */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+  color: var(--text);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all var(--transition);
+  font-family: inherit;
+  white-space: nowrap;
+}
+
+.btn:hover {
+  background: var(--bg-card-hover);
+  border-color: var(--border-hover);
+}
+
+.btn-primary {
+  background: var(--accent-dim);
+  border-color: var(--accent);
+  color: var(--text-bright);
+}
+
+.btn-primary:hover {
+  background: var(--accent);
+  color: var(--bg-darkest);
+}
+
+.btn-danger {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.btn-danger:hover {
+  background: var(--danger);
+  color: var(--text-bright);
+}
+
+.btn-success {
+  border-color: var(--success);
+  color: var(--success);
+}
+
+.btn-success:hover {
+  background: var(--success);
+  color: var(--text-bright);
+}
+
+.btn-sm {
+  padding: 0.3rem 0.6rem;
+  font-size: 0.78rem;
+}
+
+.btn-icon {
+  padding: 0.4rem;
+  width: 32px;
+  height: 32px;
+  justify-content: center;
+}
+
+/* ===== LAYOUT ===== */
+.app-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+/* ===== VIEWS ===== */
+.view {
+  display: none;
+}
+
+.view.active {
+  display: block;
+}
+
+/* ===== ROSTER LIST VIEW ===== */
+.roster-list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.roster-list-header h2 {
+  color: var(--accent);
+  font-size: 1.2rem;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.roster-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1rem;
+}
+
+.roster-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.2rem;
+  cursor: pointer;
+  transition: all var(--transition);
+  position: relative;
+  overflow: hidden;
+}
+
+.roster-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--accent-dim), var(--accent), var(--accent-dim));
+  opacity: 0;
+  transition: opacity var(--transition);
+}
+
+.roster-card:hover {
+  border-color: var(--accent-dim);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 20px var(--shadow);
+}
+
+.roster-card:hover::before {
+  opacity: 1;
+}
+
+.roster-card-name {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-bright);
+  margin-bottom: 0.3rem;
+}
+
+.roster-card-warband {
+  font-size: 0.85rem;
+  color: var(--accent);
+  margin-bottom: 0.8rem;
+}
+
+.roster-card-stats {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.8rem;
+  color: var(--text-dim);
+}
+
+.roster-card-stat {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.roster-card-stat strong {
+  color: var(--text);
+}
+
+.roster-card-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--border);
+}
+
+.empty-state {
+  text-align: center;
+  padding: 4rem 2rem;
+  color: var(--text-dim);
+}
+
+.empty-state h3 {
+  color: var(--accent);
+  font-size: 1.3rem;
+  margin-bottom: 0.5rem;
+}
+
+.empty-state p {
+  margin-bottom: 1.5rem;
+}
+
+/* ===== ROSTER CREATION MODAL ===== */
+.modal-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  z-index: 200;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.modal-overlay.active {
+  display: flex;
+}
+
+.modal {
+  background: var(--bg-dark);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  width: 100%;
+  max-width: 600px;
+  max-height: 85vh;
+  overflow-y: auto;
+  box-shadow: 0 10px 50px var(--shadow);
+}
+
+.modal-header {
+  padding: 1.2rem 1.5rem;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: sticky;
+  top: 0;
+  background: var(--bg-dark);
+  z-index: 1;
+}
+
+.modal-header h3 {
+  color: var(--accent);
+  font-size: 1.1rem;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.modal-body {
+  padding: 1.5rem;
+}
+
+.modal-footer {
+  padding: 1rem 1.5rem;
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  position: sticky;
+  bottom: 0;
+  background: var(--bg-dark);
+}
+
+/* ===== FORMS ===== */
+.form-group {
+  margin-bottom: 1.2rem;
+}
+
+.form-group label {
+  display: block;
+  font-size: 0.82rem;
+  color: var(--text-dim);
+  margin-bottom: 0.4rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.form-control {
+  width: 100%;
+  padding: 0.6rem 0.8rem;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 0.9rem;
+  font-family: inherit;
+  transition: border-color var(--transition);
+}
+
+.form-control:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-glow);
+}
+
+select.form-control {
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%239998a5' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.8rem center;
+  padding-right: 2rem;
+}
+
+/* ===== ROSTER EDITOR VIEW ===== */
+.roster-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.roster-info h2 {
+  color: var(--accent);
+  font-size: 1.3rem;
+  letter-spacing: 1px;
+}
+
+.roster-info .warband-type {
+  color: var(--text-dim);
+  font-size: 0.85rem;
+  margin-top: 0.2rem;
+}
+
+.roster-summary {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.summary-stat {
+  text-align: center;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.6rem 1rem;
+  min-width: 80px;
+}
+
+.summary-stat .label {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.summary-stat .value {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--text-bright);
+}
+
+.summary-stat .value.gold {
+  color: var(--accent);
+}
+
+.summary-stat .value.danger {
+  color: var(--danger);
+}
+
+/* ===== SECTION PANELS ===== */
+.section-panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  margin-bottom: 1rem;
+  overflow: hidden;
+}
+
+.section-header {
+  padding: 0.8rem 1.2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: linear-gradient(135deg, var(--bg-card) 0%, var(--bg-card-hover) 100%);
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  user-select: none;
+}
+
+.section-header h3 {
+  font-size: 0.95rem;
+  color: var(--accent);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.section-header .toggle-icon {
+  transition: transform var(--transition);
+  color: var(--text-dim);
+  font-size: 0.8rem;
+}
+
+.section-header.collapsed .toggle-icon {
+  transform: rotate(-90deg);
+}
+
+.section-content {
+  padding: 1rem 1.2rem;
+}
+
+.section-content.collapsed {
+  display: none;
+}
+
+/* ===== WARRIOR CARDS ===== */
+.warrior-card {
+  background: var(--bg-dark);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin-bottom: 0.8rem;
+  overflow: hidden;
+  transition: border-color var(--transition);
+}
+
+.warrior-card:hover {
+  border-color: var(--border-hover);
+}
+
+.warrior-card-header {
+  padding: 0.7rem 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.warrior-card-header .warrior-name {
+  font-weight: 600;
+  color: var(--text-bright);
+  font-size: 0.92rem;
+}
+
+.warrior-card-header .warrior-type {
+  color: var(--text-dim);
+  font-size: 0.78rem;
+  margin-left: 0.5rem;
+}
+
+.warrior-card-header .warrior-cost {
+  color: var(--accent);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.warrior-card-body {
+  padding: 0.8rem 1rem;
+  border-top: 1px solid var(--border);
+}
+
+.warrior-card-body.collapsed {
+  display: none;
+}
+
+/* ===== STAT LINE ===== */
+.stat-line {
+  display: flex;
+  gap: 2px;
+  margin-bottom: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.stat-cell {
+  text-align: center;
+  min-width: 38px;
+  flex: 1;
+}
+
+.stat-cell .stat-label {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 0.2rem;
+  background: rgba(201, 168, 76, 0.08);
+  border-radius: 3px 3px 0 0;
+}
+
+.stat-cell .stat-value {
+  font-size: 0.9rem;
+  font-weight: 700;
+  padding: 0.3rem;
+  background: var(--bg-input);
+  border-radius: 0 0 3px 3px;
+  color: var(--text-bright);
+}
+
+.stat-cell .stat-value.modified {
+  color: var(--accent);
+}
+
+/* ===== EQUIPMENT / SKILLS TAGS ===== */
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-top: 0.5rem;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.5rem;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  font-size: 0.75rem;
+  color: var(--text-dim);
+}
+
+.tag.equipment {
+  border-color: var(--accent-dim);
+  color: var(--accent);
+}
+
+.tag.skill {
+  border-color: #4a6fa5;
+  color: #6a9fd8;
+}
+
+.tag.injury {
+  border-color: var(--danger);
+  color: #d88;
+}
+
+.tag .tag-remove {
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
+.tag .tag-remove:hover {
+  color: var(--danger);
+}
+
+.tag-section {
+  margin-bottom: 0.6rem;
+}
+
+.tag-section-label {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 0.3rem;
+}
+
+/* ===== WARRIOR ACTIONS ===== */
+.warrior-actions {
+  display: flex;
+  gap: 0.4rem;
+  margin-top: 0.8rem;
+  padding-top: 0.6rem;
+  border-top: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+
+/* ===== EXPERIENCE BAR ===== */
+.exp-bar-container {
+  margin-top: 0.6rem;
+}
+
+.exp-bar-label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.72rem;
+  color: var(--text-dim);
+  margin-bottom: 0.2rem;
+}
+
+.exp-bar {
+  height: 6px;
+  background: var(--bg-input);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.exp-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent-dim), var(--accent));
+  border-radius: 3px;
+  transition: width 0.4s ease;
+}
+
+/* ===== BATTLE LOG ===== */
+.battle-log {
+  margin-top: 1rem;
+}
+
+.battle-log-entry {
+  background: var(--bg-dark);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.8rem 1rem;
+  margin-bottom: 0.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.battle-log-entry .battle-info {
+  flex: 1;
+}
+
+.battle-log-entry .battle-number {
+  font-weight: 700;
+  color: var(--accent);
+  font-size: 0.85rem;
+}
+
+.battle-log-entry .battle-result {
+  font-size: 0.82rem;
+  color: var(--text-dim);
+}
+
+.battle-log-entry .battle-date {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+/* ===== NOTIFICATIONS / TOAST ===== */
+.toast-container {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 300;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.toast {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.8rem 1.2rem;
+  color: var(--text);
+  font-size: 0.85rem;
+  box-shadow: 0 4px 20px var(--shadow);
+  animation: toastIn 0.3s ease;
+  max-width: 320px;
+}
+
+.toast.success { border-color: var(--success); }
+.toast.error { border-color: var(--danger); }
+.toast.info { border-color: var(--accent); }
+
+@keyframes toastIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ===== PROGRESS TRACKING VIEW ===== */
+.campaign-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.campaign-stat-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem;
+  text-align: center;
+}
+
+.campaign-stat-card .stat-icon {
+  font-size: 1.3rem;
+  margin-bottom: 0.3rem;
+}
+
+.campaign-stat-card .stat-val {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.campaign-stat-card .stat-lbl {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* ===== WARBAND RATING BAR ===== */
+.rating-display {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem 1.2rem;
+  margin-bottom: 1rem;
+}
+
+.rating-display .rating-value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.rating-display .rating-label {
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* ===== TREASURY / STASH ===== */
+.treasury-section {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.treasury-item {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.8rem 1.2rem;
+  flex: 1;
+  min-width: 120px;
+}
+
+.treasury-item .treasury-label {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.treasury-item .treasury-value {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.treasury-inline {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.treasury-inline input {
+  width: 80px;
+  text-align: center;
+}
+
+/* ===== TABS ===== */
+.tab-bar {
+  display: flex;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 1.2rem;
+  overflow-x: auto;
+}
+
+.tab-btn {
+  padding: 0.7rem 1.2rem;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-dim);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all var(--transition);
+  white-space: nowrap;
+  font-family: inherit;
+}
+
+.tab-btn:hover {
+  color: var(--text);
+}
+
+.tab-btn.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.tab-content {
+  display: none;
+}
+
+.tab-content.active {
+  display: block;
+}
+
+/* ===== RESPONSIVE ===== */
+@media (max-width: 768px) {
+  .app-header {
+    padding: 0.8rem 1rem;
+  }
+
+  .app-title {
+    font-size: 1.1rem;
+  }
+
+  .app-container {
+    padding: 1rem;
+  }
+
+  .roster-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .roster-header {
+    flex-direction: column;
+  }
+
+  .roster-summary {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .campaign-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .stat-line {
+    gap: 1px;
+  }
+
+  .stat-cell {
+    min-width: 32px;
+  }
+}
+
+@media (max-width: 480px) {
+  html {
+    font-size: 14px;
+  }
+
+  .summary-stat {
+    min-width: 65px;
+    padding: 0.4rem 0.6rem;
+  }
+
+  .campaign-stats {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+/* ===== UTILITY ===== */
+.mt-1 { margin-top: 0.5rem; }
+.mt-2 { margin-top: 1rem; }
+.mb-1 { margin-bottom: 0.5rem; }
+.mb-2 { margin-bottom: 1rem; }
+.flex-grow { flex-grow: 1; }
+.text-accent { color: var(--accent); }
+.text-dim { color: var(--text-dim); }
+.text-muted { color: var(--text-muted); }
+.text-right { text-align: right; }
+.text-center { text-align: center; }
+.hidden { display: none !important; }
+
+/* ===== INLINE EDIT ===== */
+.inline-edit {
+  background: transparent;
+  border: 1px solid transparent;
+  color: inherit;
+  font: inherit;
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+  cursor: text;
+  transition: all var(--transition);
+}
+
+.inline-edit:hover {
+  border-color: var(--border);
+}
+
+.inline-edit:focus {
+  outline: none;
+  border-color: var(--accent);
+  background: var(--bg-input);
+}
+
+/* ===== CONFIRMATION DIALOG ===== */
+.confirm-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: 250;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.confirm-overlay.active {
+  display: flex;
+}
+
+.confirm-box {
+  background: var(--bg-dark);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  max-width: 400px;
+  width: 100%;
+  text-align: center;
+}
+
+.confirm-box h4 {
+  color: var(--accent);
+  margin-bottom: 0.8rem;
+}
+
+.confirm-box p {
+  color: var(--text-dim);
+  margin-bottom: 1.2rem;
+  font-size: 0.9rem;
+}
+
+.confirm-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+/* ===== NOTES TEXTAREA ===== */
+.notes-area {
+  width: 100%;
+  min-height: 80px;
+  padding: 0.6rem 0.8rem;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 0.85rem;
+  font-family: inherit;
+  resize: vertical;
+  transition: border-color var(--transition);
+}
+
+.notes-area:focus {
+  outline: none;
+  border-color: var(--accent);
+}

--- a/data/advancement.json
+++ b/data/advancement.json
@@ -1,0 +1,48 @@
+{
+  "heroAdvancement": {
+    "expThresholds": [2, 4, 6, 8, 11, 14, 17, 20, 24, 28, 32, 36, 41, 46, 51, 57, 63, 69, 76, 83, 90],
+    "advanceRoll": {
+      "2-4": { "name": "New Skill", "description": "Choose a new skill from the warrior's available skill categories." },
+      "5": { "name": "+1 Strength", "description": "Increase Strength by 1." },
+      "6": { "name": "+1 Attack", "description": "Increase Attacks by 1." },
+      "7": { "name": "Roll Again (Two Stats)", "description": "Roll twice on this table. Each roll must choose a different result." },
+      "8": { "name": "+1 BS", "description": "Increase Ballistic Skill by 1." },
+      "9": { "name": "+1 WS", "description": "Increase Weapon Skill by 1." },
+      "10": { "name": "+1 Initiative", "description": "Increase Initiative by 1." },
+      "11": { "name": "+1 Leadership", "description": "Increase Leadership by 1." },
+      "12": { "name": "+1 Wound", "description": "Increase Wounds by 1." }
+    }
+  },
+  "henchmenAdvancement": {
+    "note": "Henchmen gain experience as a group. When they accumulate enough, the group levels up.",
+    "advanceRoll": {
+      "2-4": { "name": "+1 Initiative", "description": "Increase Initiative by 1." },
+      "5": { "name": "+1 Strength", "description": "Increase Strength by 1." },
+      "6": { "name": "+1 Attack", "description": "Increase Attacks by 1." },
+      "7": { "name": "Roll Again (Two Stats)", "description": "Roll twice on this table." },
+      "8": { "name": "+1 BS", "description": "Increase Ballistic Skill by 1." },
+      "9": { "name": "+1 WS", "description": "Increase Weapon Skill by 1." },
+      "10": { "name": "+1 Initiative", "description": "Increase Initiative by 1." },
+      "11": { "name": "+1 Leadership", "description": "Increase Leadership by 1." },
+      "12": { "name": "The lad's got talent!", "description": "This henchman becomes a Hero! Gains 'Lad's Got Talent' special rule." }
+    }
+  },
+  "experienceRewards": {
+    "surviving": { "value": 1, "description": "+1 XP for surviving a battle." },
+    "perWound": { "value": 1, "description": "+1 XP per enemy taken out of action." },
+    "winning": { "value": 1, "description": "+1 XP for being on the winning warband (heroes only)." },
+    "perWyrdstone": { "value": 1, "description": "+1 XP per wyrdstone shard found (heroes only)." }
+  },
+  "maxStats": {
+    "note": "Maximum characteristic values for stat increases",
+    "M": 10,
+    "WS": 10,
+    "BS": 10,
+    "S": 7,
+    "T": 7,
+    "W": 5,
+    "I": 10,
+    "A": 5,
+    "Ld": 10
+  }
+}

--- a/data/equipment.json
+++ b/data/equipment.json
@@ -1,0 +1,72 @@
+{
+  "categories": {
+    "hand_to_hand": {
+      "name": "Hand-to-Hand Combat Weapons",
+      "items": [
+        { "id": "dagger", "name": "Dagger", "cost": 2, "range": "Close Combat", "strength": "As user", "rules": "+1 Attack when used in pairs. Enemy armour saves at -1 penalty.", "category": "hand_to_hand" },
+        { "id": "hammer", "name": "Hammer", "cost": 3, "range": "Close Combat", "strength": "As user", "rules": "Concussion: enemy takes -1 to armour save.", "category": "hand_to_hand" },
+        { "id": "mace", "name": "Mace", "cost": 3, "range": "Close Combat", "strength": "As user", "rules": "Concussion: enemy takes -1 to armour save.", "category": "hand_to_hand" },
+        { "id": "axe", "name": "Axe", "cost": 5, "range": "Close Combat", "strength": "As user", "rules": "Cutting edge: +1 to injury rolls.", "category": "hand_to_hand" },
+        { "id": "sword", "name": "Sword", "cost": 10, "range": "Close Combat", "strength": "As user", "rules": "Parry: may force opponent to re-roll one successful hit per turn.", "category": "hand_to_hand" },
+        { "id": "club", "name": "Club", "cost": 3, "range": "Close Combat", "strength": "As user", "rules": "Concussion: enemy takes -1 to armour save.", "category": "hand_to_hand" },
+        { "id": "spear", "name": "Spear", "cost": 10, "range": "Close Combat", "strength": "As user", "rules": "Strike first on the charge. +1 Strength on the charge.", "category": "hand_to_hand" },
+        { "id": "halberd", "name": "Halberd", "cost": 10, "range": "Close Combat", "strength": "As user +1", "rules": "+1 Strength. Two-handed: cannot use with shield.", "category": "hand_to_hand" },
+        { "id": "double_handed_weapon", "name": "Double-Handed Weapon", "cost": 15, "range": "Close Combat", "strength": "As user +2", "rules": "+2 Strength. Two-handed. Strikes last.", "category": "hand_to_hand" },
+        { "id": "flail", "name": "Flail", "cost": 15, "range": "Close Combat", "strength": "As user +2", "rules": "+2 Strength in first turn of combat. Two-handed.", "category": "hand_to_hand" },
+        { "id": "morning_star", "name": "Morning Star", "cost": 15, "range": "Close Combat", "strength": "As user +1", "rules": "+1 Strength in first turn of combat.", "category": "hand_to_hand" },
+        { "id": "steel_whip", "name": "Steel Whip", "cost": 10, "range": "Close Combat", "strength": "As user", "rules": "Cannot be parried. Counts as two-handed.", "category": "hand_to_hand" },
+        { "id": "fighting_claws", "name": "Fighting Claws (Pair)", "cost": 35, "range": "Close Combat", "strength": "As user", "rules": "+1 Attack. +1 to climb tests. Parry.", "category": "hand_to_hand" },
+        { "id": "weeping_blades", "name": "Weeping Blades (Pair)", "cost": 50, "range": "Close Combat", "strength": "As user", "rules": "+1 Attack. Wounds always count as critical on 5+.", "category": "hand_to_hand" }
+      ]
+    },
+    "missiles": {
+      "name": "Missile Weapons",
+      "items": [
+        { "id": "short_bow", "name": "Short Bow", "cost": 5, "range": "16\"", "strength": "3", "rules": "None.", "category": "missiles" },
+        { "id": "bow", "name": "Bow", "cost": 10, "range": "24\"", "strength": "3", "rules": "None.", "category": "missiles" },
+        { "id": "long_bow", "name": "Long Bow", "cost": 15, "range": "30\"", "strength": "3", "rules": "None.", "category": "missiles" },
+        { "id": "elf_bow", "name": "Elf Bow", "cost": 35, "range": "36\"", "strength": "3", "rules": "Ignores movement penalty.", "category": "missiles" },
+        { "id": "crossbow", "name": "Crossbow", "cost": 25, "range": "30\"", "strength": "4", "rules": "Move or fire.", "category": "missiles" },
+        { "id": "pistol", "name": "Pistol", "cost": 15, "range": "6\"", "strength": "4", "rules": "Armour save -2. Can be used in close combat.", "category": "missiles" },
+        { "id": "duelling_pistol", "name": "Duelling Pistol", "cost": 30, "range": "10\"", "strength": "4", "rules": "Armour save -2. +1 to hit. Can be used in close combat.", "category": "missiles" },
+        { "id": "handgun", "name": "Handgun", "cost": 35, "range": "24\"", "strength": "4", "rules": "Armour save -1. Move or fire.", "category": "missiles" },
+        { "id": "blunderbuss", "name": "Blunderbuss", "cost": 30, "range": "Special", "strength": "3", "rules": "Flame template. Move or fire.", "category": "missiles" },
+        { "id": "sling", "name": "Sling", "cost": 2, "range": "18\"", "strength": "As user", "rules": "May fire twice at half range.", "category": "missiles" },
+        { "id": "throwing_knife", "name": "Throwing Knife", "cost": 10, "range": "6\"", "strength": "As user", "rules": "Thrown weapon.", "category": "missiles" },
+        { "id": "throwing_star", "name": "Throwing Star", "cost": 15, "range": "6\"", "strength": "As user", "rules": "Thrown weapon. Can throw 2 per turn.", "category": "missiles" }
+      ]
+    },
+    "armour": {
+      "name": "Armour",
+      "items": [
+        { "id": "light_armour", "name": "Light Armour", "cost": 20, "armourSave": "6+", "rules": "None.", "category": "armour" },
+        { "id": "heavy_armour", "name": "Heavy Armour", "cost": 50, "armourSave": "5+", "rules": "-1 Movement. -1 Initiative.", "category": "armour" },
+        { "id": "shield", "name": "Shield", "cost": 5, "armourSave": "6+", "rules": "Combined with other armour. Cannot use with two-handed weapons.", "category": "armour" },
+        { "id": "buckler", "name": "Buckler", "cost": 5, "armourSave": "Special", "rules": "Parry in close combat.", "category": "armour" },
+        { "id": "helmet", "name": "Helmet", "cost": 10, "armourSave": "Special", "rules": "Avoid being stunned on a 4+.", "category": "armour" },
+        { "id": "gromril_armour", "name": "Gromril Armour", "cost": 150, "armourSave": "4+", "rules": "No movement penalty. Rare 11.", "category": "armour" },
+        { "id": "ithilmar_armour", "name": "Ithilmar Armour", "cost": 90, "armourSave": "5+", "rules": "No movement penalty. Rare 11.", "category": "armour" }
+      ]
+    },
+    "miscellaneous": {
+      "name": "Miscellaneous Equipment",
+      "items": [
+        { "id": "rope_hook", "name": "Rope & Hook", "cost": 5, "rules": "+1 to climbing tests." },
+        { "id": "torch", "name": "Torch", "cost": 2, "rules": "Provides light. Causes fear in animals." },
+        { "id": "lantern", "name": "Lantern", "cost": 10, "rules": "Extended light radius." },
+        { "id": "holy_water", "name": "Holy Water", "cost": 10, "rules": "Thrown weapon. S2. Causes D3 wounds vs Undead/Possessed. One use." },
+        { "id": "lucky_charm", "name": "Lucky Charm", "cost": 10, "rules": "Ignore first hit in a battle. One use." },
+        { "id": "holy_relic", "name": "Holy Relic", "cost": 15, "rules": "+1 to Rout tests. Rare 8." },
+        { "id": "rabbits_foot", "name": "Rabbit's Foot", "cost": 10, "rules": "+1 to first exploration roll." },
+        { "id": "garlic", "name": "Garlic", "cost": 1, "rules": "Vampires must pass Ld test to charge." },
+        { "id": "healing_herbs", "name": "Healing Herbs", "cost": 20, "rules": "Re-roll one recovery roll per battle. One use. Rare 8." },
+        { "id": "cathayan_silk", "name": "Cathayan Silk Clothes", "cost": 50, "rules": "-1 to enemy hit rolls in first round of combat. Rare 9." },
+        { "id": "superior_blackpowder", "name": "Superior Blackpowder", "cost": 30, "rules": "+1 Strength for blackpowder weapons. Rare 11." },
+        { "id": "bugmans_ale", "name": "Bugman's Ale", "cost": 50, "rules": "Immune to Fear for one battle. One use. Rare 9." },
+        { "id": "tome_of_magic", "name": "Tome of Magic", "cost": 200, "rules": "+1 to casting rolls. Rare 12." },
+        { "id": "horse", "name": "Horse", "cost": 80, "rules": "M8. +2\" charge range. Rare 8." },
+        { "id": "wardog", "name": "War Dog", "cost": 25, "rules": "WS3 S3 T3 W1 I4 A1. Ld5." }
+      ]
+    }
+  }
+}

--- a/data/injuries.json
+++ b/data/injuries.json
@@ -1,0 +1,30 @@
+{
+  "heroInjuries": [
+    { "roll": "11-15", "name": "Dead", "description": "The warrior is dead. Remove from roster. All equipment is lost." },
+    { "roll": "16-21", "name": "Multiple Injuries", "description": "Roll D6 times on the serious injuries table." },
+    { "roll": "22", "name": "Leg Wound", "description": "-1 Movement permanently." },
+    { "roll": "23", "name": "Arm Wound", "description": "-1 Weapon Skill permanently." },
+    { "roll": "24", "name": "Madness", "description": "Roll D6: 1-3 = Stupidity; 4-6 = Frenzy." },
+    { "roll": "25", "name": "Smashed Leg", "description": "Cannot run but may still charge. -1 Movement permanently." },
+    { "roll": "26", "name": "Chest Wound", "description": "-1 Toughness permanently." },
+    { "roll": "31", "name": "Blinded in One Eye", "description": "-1 Ballistic Skill permanently." },
+    { "roll": "32", "name": "Old Battle Wound", "description": "Before each battle roll D6: on 1, misses the battle." },
+    { "roll": "33", "name": "Nervous Condition", "description": "-1 Initiative permanently." },
+    { "roll": "34", "name": "Hand Injury", "description": "-1 Weapon Skill permanently." },
+    { "roll": "35", "name": "Deep Wound", "description": "Misses the next battle while recovering." },
+    { "roll": "36", "name": "Robbed", "description": "All equipment lost." },
+    { "roll": "41-55", "name": "Full Recovery", "description": "The warrior makes a full recovery." },
+    { "roll": "56", "name": "Bitter Enmity", "description": "Hates the warband that caused the injury." },
+    { "roll": "61", "name": "Captured", "description": "The warrior is captured by the enemy. Roll after game to see fate." },
+    { "roll": "62", "name": "Hardened", "description": "Immune to Fear." },
+    { "roll": "63", "name": "Horrible Scars", "description": "Causes Fear." },
+    { "roll": "64", "name": "Sold to the Pits", "description": "Gains D6 experience." },
+    { "roll": "65", "name": "Survives Against the Odds", "description": "Gains +1 Experience." },
+    { "roll": "66", "name": "Survives Against the Odds", "description": "Gains +1 Experience." }
+  ],
+  "henchmenInjuries": [
+    { "roll": "1-2", "name": "Dead", "description": "The henchman is removed from the roster." },
+    { "roll": "3-4", "name": "Multiple Injuries", "description": "The henchman must miss the next game." },
+    { "roll": "5-6", "name": "Full Recovery", "description": "The henchman makes a full recovery." }
+  ]
+}

--- a/data/skills.json
+++ b/data/skills.json
@@ -1,0 +1,59 @@
+{
+  "skillCategories": {
+    "combat": {
+      "name": "Combat Skills",
+      "skills": [
+        { "id": "strike_to_injure", "name": "Strike to Injure", "description": "+1 to all injury rolls in close combat." },
+        { "id": "combat_master", "name": "Combat Master", "description": "Can fight against any number of opponents without penalty." },
+        { "id": "weapons_training", "name": "Weapons Training", "description": "Can use any hand-to-hand combat weapon." },
+        { "id": "web_of_steel", "name": "Web of Steel", "description": "If armed with two weapons, enemies suffer -1 to hit in close combat." },
+        { "id": "expert_swordsman", "name": "Expert Swordsman", "description": "Re-roll all missed attacks when using a sword." },
+        { "id": "step_aside", "name": "Step Aside", "description": "4+ ward save (dodge) against one hit per combat phase." }
+      ]
+    },
+    "shooting": {
+      "name": "Shooting Skills",
+      "skills": [
+        { "id": "quick_shot", "name": "Quick Shot", "description": "Can fire twice per turn with ranged weapons (but at -1 to hit)." },
+        { "id": "pistolier", "name": "Pistolier", "description": "Can fire while running. No penalties for moving and shooting with pistols." },
+        { "id": "eagle_eyes", "name": "Eagle Eyes", "description": "+6\" range with ranged weapons." },
+        { "id": "weapons_expert", "name": "Weapons Expert", "description": "Can use any missile weapon." },
+        { "id": "nimble", "name": "Nimble", "description": "No movement penalty for shooting." },
+        { "id": "trick_shooter", "name": "Trick Shooter", "description": "Ignore penalties for cover and obstacles when shooting." }
+      ]
+    },
+    "academic": {
+      "name": "Academic Skills",
+      "skills": [
+        { "id": "battle_tongue", "name": "Battle Tongue", "description": "One warrior within 6\" can re-roll one failed Leadership test per turn." },
+        { "id": "sorcery", "name": "Sorcery", "description": "+1 to casting attempts (Wizards only)." },
+        { "id": "streetwise", "name": "Streetwise", "description": "-1 to Rare item availability rolls." },
+        { "id": "haggle", "name": "Haggle", "description": "Reduce the cost of rare items by 2D6 gold crowns (minimum 1gc)." },
+        { "id": "arcane_lore", "name": "Arcane Lore", "description": "May learn spells from a random magic list (must have Wizard rule)." },
+        { "id": "wyrdstone_hunter", "name": "Wyrdstone Hunter", "description": "+1 to wyrdstone discovery rolls." }
+      ]
+    },
+    "strength": {
+      "name": "Strength Skills",
+      "skills": [
+        { "id": "mighty_blow", "name": "Mighty Blow", "description": "+1 Strength in close combat." },
+        { "id": "pit_fighter", "name": "Pit Fighter", "description": "+1 Attack, +1 Weapon Skill when fighting against two or more opponents." },
+        { "id": "resilient", "name": "Resilient", "description": "+1 Toughness." },
+        { "id": "fearsome", "name": "Fearsome", "description": "Causes Fear." },
+        { "id": "strongman", "name": "Strongman", "description": "Can use two-handed weapons without the 'strikes last' penalty." },
+        { "id": "unstoppable_charge", "name": "Unstoppable Charge", "description": "+1 Attack on the turn this model charges." }
+      ]
+    },
+    "speed": {
+      "name": "Speed Skills",
+      "skills": [
+        { "id": "leap", "name": "Leap", "description": "Can jump up to 6\" across gaps. No Initiative test required." },
+        { "id": "sprint", "name": "Sprint", "description": "+1 Movement." },
+        { "id": "acrobat", "name": "Acrobat", "description": "Falls do not cause damage." },
+        { "id": "lightning_reflexes", "name": "Lightning Reflexes", "description": "Always strikes first in close combat." },
+        { "id": "jump_up", "name": "Jump Up", "description": "Can stand up for free instead of using half movement." },
+        { "id": "dodge", "name": "Dodge", "description": "5+ ward save against ranged attacks." }
+      ]
+    }
+  }
+}

--- a/data/warbands.json
+++ b/data/warbands.json
@@ -1,0 +1,583 @@
+{
+  "warbands": [
+    {
+      "id": "reikland",
+      "name": "Reikland Mercenaries",
+      "source": "Core",
+      "description": "Hardened soldiers from the Reikland province, well-equipped and disciplined.",
+      "startingGold": 500,
+      "maxWarband": 15,
+      "alignment": "Human Mercenaries",
+      "heroes": [
+        {
+          "type": "mercenary_captain",
+          "name": "Mercenary Captain",
+          "max": 1,
+          "required": true,
+          "cost": 60,
+          "stats": { "M": 4, "WS": 4, "BS": 4, "S": 3, "T": 3, "W": 1, "I": 4, "A": 1, "Ld": 8 },
+          "specialRules": ["Leader"],
+          "startingExp": 20,
+          "skillAccess": ["combat", "shooting", "academic", "strength", "speed"]
+        },
+        {
+          "type": "champion",
+          "name": "Champion",
+          "max": 2,
+          "required": false,
+          "cost": 35,
+          "stats": { "M": 4, "WS": 4, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": [],
+          "startingExp": 8,
+          "skillAccess": ["combat", "shooting", "strength", "speed"]
+        },
+        {
+          "type": "youngblood",
+          "name": "Youngblood",
+          "max": 2,
+          "required": false,
+          "cost": 15,
+          "stats": { "M": 4, "WS": 2, "BS": 2, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 6 },
+          "specialRules": [],
+          "startingExp": 0,
+          "skillAccess": ["combat", "shooting", "speed"]
+        }
+      ],
+      "henchmen": [
+        {
+          "type": "warrior",
+          "name": "Warrior",
+          "cost": 25,
+          "stats": { "M": 4, "WS": 3, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": [],
+          "maxGroupSize": 5
+        },
+        {
+          "type": "marksman",
+          "name": "Marksman",
+          "cost": 25,
+          "stats": { "M": 4, "WS": 3, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": [],
+          "maxGroupSize": 7
+        },
+        {
+          "type": "swordsman",
+          "name": "Swordsman",
+          "cost": 35,
+          "stats": { "M": 4, "WS": 4, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": ["Expert Swordsmen"],
+          "maxGroupSize": 5
+        }
+      ],
+      "equipmentAccess": {
+        "heroes": ["hand_to_hand", "missiles", "armour"],
+        "henchmen": ["hand_to_hand", "missiles", "armour"]
+      }
+    },
+    {
+      "id": "middenheim",
+      "name": "Middenheim Mercenaries",
+      "source": "Core",
+      "description": "Fierce warriors from the city of the White Wolf, known for their ferocity in combat.",
+      "startingGold": 500,
+      "maxWarband": 15,
+      "alignment": "Human Mercenaries",
+      "heroes": [
+        {
+          "type": "mercenary_captain",
+          "name": "Mercenary Captain",
+          "max": 1,
+          "required": true,
+          "cost": 60,
+          "stats": { "M": 4, "WS": 4, "BS": 4, "S": 3, "T": 3, "W": 1, "I": 4, "A": 1, "Ld": 8 },
+          "specialRules": ["Leader"],
+          "startingExp": 20,
+          "skillAccess": ["combat", "shooting", "academic", "strength", "speed"]
+        },
+        {
+          "type": "champion",
+          "name": "Champion",
+          "max": 2,
+          "required": false,
+          "cost": 35,
+          "stats": { "M": 4, "WS": 4, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": [],
+          "startingExp": 8,
+          "skillAccess": ["combat", "strength", "speed"]
+        },
+        {
+          "type": "youngblood",
+          "name": "Youngblood",
+          "max": 2,
+          "required": false,
+          "cost": 15,
+          "stats": { "M": 4, "WS": 2, "BS": 2, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 6 },
+          "specialRules": [],
+          "startingExp": 0,
+          "skillAccess": ["combat", "shooting", "speed"]
+        }
+      ],
+      "henchmen": [
+        {
+          "type": "warrior",
+          "name": "Warrior",
+          "cost": 25,
+          "stats": { "M": 4, "WS": 3, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": [],
+          "maxGroupSize": 5
+        },
+        {
+          "type": "marksman",
+          "name": "Marksman",
+          "cost": 25,
+          "stats": { "M": 4, "WS": 3, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": [],
+          "maxGroupSize": 7
+        }
+      ],
+      "equipmentAccess": {
+        "heroes": ["hand_to_hand", "missiles", "armour"],
+        "henchmen": ["hand_to_hand", "missiles", "armour"]
+      }
+    },
+    {
+      "id": "marienburg",
+      "name": "Marienburg Mercenaries",
+      "source": "Core",
+      "description": "Wealthy merchants and their hired soldiers from the richest city in the Old World.",
+      "startingGold": 600,
+      "maxWarband": 15,
+      "alignment": "Human Mercenaries",
+      "heroes": [
+        {
+          "type": "mercenary_captain",
+          "name": "Mercenary Captain",
+          "max": 1,
+          "required": true,
+          "cost": 60,
+          "stats": { "M": 4, "WS": 4, "BS": 4, "S": 3, "T": 3, "W": 1, "I": 4, "A": 1, "Ld": 8 },
+          "specialRules": ["Leader"],
+          "startingExp": 20,
+          "skillAccess": ["combat", "shooting", "academic", "strength", "speed"]
+        },
+        {
+          "type": "champion",
+          "name": "Champion",
+          "max": 2,
+          "required": false,
+          "cost": 35,
+          "stats": { "M": 4, "WS": 4, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": [],
+          "startingExp": 8,
+          "skillAccess": ["combat", "shooting", "strength", "speed"]
+        },
+        {
+          "type": "youngblood",
+          "name": "Youngblood",
+          "max": 2,
+          "required": false,
+          "cost": 15,
+          "stats": { "M": 4, "WS": 2, "BS": 2, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 6 },
+          "specialRules": [],
+          "startingExp": 0,
+          "skillAccess": ["combat", "shooting", "speed"]
+        }
+      ],
+      "henchmen": [
+        {
+          "type": "warrior",
+          "name": "Warrior",
+          "cost": 25,
+          "stats": { "M": 4, "WS": 3, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": [],
+          "maxGroupSize": 5
+        },
+        {
+          "type": "marksman",
+          "name": "Marksman",
+          "cost": 25,
+          "stats": { "M": 4, "WS": 3, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": [],
+          "maxGroupSize": 7
+        },
+        {
+          "type": "swordsman",
+          "name": "Swordsman",
+          "cost": 35,
+          "stats": { "M": 4, "WS": 4, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": ["Expert Swordsmen"],
+          "maxGroupSize": 5
+        }
+      ],
+      "equipmentAccess": {
+        "heroes": ["hand_to_hand", "missiles", "armour"],
+        "henchmen": ["hand_to_hand", "missiles", "armour"]
+      }
+    },
+    {
+      "id": "witch_hunters",
+      "name": "Witch Hunters",
+      "source": "Core",
+      "description": "Fanatical servants of Sigmar, dedicated to purging evil and corruption.",
+      "startingGold": 500,
+      "maxWarband": 15,
+      "alignment": "Witch Hunters",
+      "heroes": [
+        {
+          "type": "witch_hunter_captain",
+          "name": "Witch Hunter Captain",
+          "max": 1,
+          "required": true,
+          "cost": 60,
+          "stats": { "M": 4, "WS": 4, "BS": 4, "S": 3, "T": 3, "W": 1, "I": 4, "A": 1, "Ld": 8 },
+          "specialRules": ["Leader", "Burn the Witch!"],
+          "startingExp": 20,
+          "skillAccess": ["combat", "shooting", "academic", "strength", "speed"]
+        },
+        {
+          "type": "warrior_priest",
+          "name": "Warrior Priest",
+          "max": 1,
+          "required": false,
+          "cost": 40,
+          "stats": { "M": 4, "WS": 3, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 8 },
+          "specialRules": ["Prayers of Sigmar"],
+          "startingExp": 12,
+          "skillAccess": ["combat", "academic", "strength"]
+        },
+        {
+          "type": "witch_hunter",
+          "name": "Witch Hunter",
+          "max": 3,
+          "required": false,
+          "cost": 25,
+          "stats": { "M": 4, "WS": 3, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": ["Burn the Witch!"],
+          "startingExp": 0,
+          "skillAccess": ["combat", "shooting", "academic", "speed"]
+        }
+      ],
+      "henchmen": [
+        {
+          "type": "zealot",
+          "name": "Zealot",
+          "cost": 20,
+          "stats": { "M": 4, "WS": 2, "BS": 2, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": [],
+          "maxGroupSize": 5
+        },
+        {
+          "type": "flagellant",
+          "name": "Flagellant",
+          "cost": 40,
+          "stats": { "M": 4, "WS": 3, "BS": 3, "S": 3, "T": 4, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": ["Fanatical"],
+          "maxGroupSize": 5
+        },
+        {
+          "type": "warhound",
+          "name": "Warhound",
+          "cost": 15,
+          "stats": { "M": 6, "WS": 4, "BS": 0, "S": 4, "T": 3, "W": 1, "I": 4, "A": 1, "Ld": 5 },
+          "specialRules": ["Animal"],
+          "maxGroupSize": 5
+        }
+      ],
+      "equipmentAccess": {
+        "heroes": ["hand_to_hand", "missiles", "armour"],
+        "henchmen": ["hand_to_hand", "armour"]
+      }
+    },
+    {
+      "id": "sisters_of_sigmar",
+      "name": "Sisters of Sigmar",
+      "source": "Core",
+      "description": "Holy warrior women of Sigmar, fighting to cleanse the cursed city.",
+      "startingGold": 500,
+      "maxWarband": 15,
+      "alignment": "Sisters of Sigmar",
+      "heroes": [
+        {
+          "type": "sigmarite_matriarch",
+          "name": "Sigmarite Matriarch",
+          "max": 1,
+          "required": true,
+          "cost": 70,
+          "stats": { "M": 4, "WS": 4, "BS": 4, "S": 3, "T": 3, "W": 1, "I": 4, "A": 1, "Ld": 8 },
+          "specialRules": ["Leader", "Prayers of Sigmar"],
+          "startingExp": 20,
+          "skillAccess": ["combat", "academic", "strength", "speed"]
+        },
+        {
+          "type": "sister_superior",
+          "name": "Sister Superior",
+          "max": 3,
+          "required": false,
+          "cost": 35,
+          "stats": { "M": 4, "WS": 4, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": [],
+          "startingExp": 8,
+          "skillAccess": ["combat", "academic", "strength", "speed"]
+        },
+        {
+          "type": "augur",
+          "name": "Augur",
+          "max": 1,
+          "required": false,
+          "cost": 25,
+          "stats": { "M": 4, "WS": 2, "BS": 2, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": ["Blessed Sight"],
+          "startingExp": 0,
+          "skillAccess": ["combat", "academic", "speed"]
+        }
+      ],
+      "henchmen": [
+        {
+          "type": "sigmarite_sister",
+          "name": "Sigmarite Sister",
+          "cost": 25,
+          "stats": { "M": 4, "WS": 3, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": [],
+          "maxGroupSize": 10
+        }
+      ],
+      "equipmentAccess": {
+        "heroes": ["hand_to_hand", "armour"],
+        "henchmen": ["hand_to_hand", "armour"]
+      }
+    },
+    {
+      "id": "undead",
+      "name": "The Undead",
+      "source": "Core",
+      "description": "Risen dead and vampiric lords seeking the cursed wyrdstone.",
+      "startingGold": 500,
+      "maxWarband": 15,
+      "alignment": "Undead",
+      "heroes": [
+        {
+          "type": "vampire",
+          "name": "Vampire",
+          "max": 1,
+          "required": true,
+          "cost": 110,
+          "stats": { "M": 6, "WS": 4, "BS": 4, "S": 4, "T": 4, "W": 2, "I": 5, "A": 2, "Ld": 8 },
+          "specialRules": ["Leader", "Fear", "Immune to Psychology", "Immune to Poison", "No Pain"],
+          "startingExp": 20,
+          "skillAccess": ["combat", "academic", "strength", "speed"]
+        },
+        {
+          "type": "necromancer",
+          "name": "Necromancer",
+          "max": 1,
+          "required": false,
+          "cost": 35,
+          "stats": { "M": 4, "WS": 3, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": ["Wizard", "Spells of the Undead"],
+          "startingExp": 8,
+          "skillAccess": ["academic", "speed"]
+        },
+        {
+          "type": "dreg",
+          "name": "Dreg",
+          "max": 3,
+          "required": false,
+          "cost": 20,
+          "stats": { "M": 4, "WS": 2, "BS": 2, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": [],
+          "startingExp": 0,
+          "skillAccess": ["combat", "shooting", "speed"]
+        }
+      ],
+      "henchmen": [
+        {
+          "type": "zombie",
+          "name": "Zombie",
+          "cost": 15,
+          "stats": { "M": 4, "WS": 2, "BS": 0, "S": 3, "T": 3, "W": 1, "I": 1, "A": 1, "Ld": 5 },
+          "specialRules": ["Fear", "Immune to Psychology", "Immune to Poison", "No Pain", "Slow"],
+          "maxGroupSize": 5
+        },
+        {
+          "type": "ghoul",
+          "name": "Ghoul",
+          "cost": 40,
+          "stats": { "M": 4, "WS": 2, "BS": 2, "S": 3, "T": 4, "W": 1, "I": 3, "A": 2, "Ld": 5 },
+          "specialRules": ["Fear"],
+          "maxGroupSize": 5
+        },
+        {
+          "type": "dire_wolf",
+          "name": "Dire Wolf",
+          "cost": 50,
+          "stats": { "M": 9, "WS": 3, "BS": 0, "S": 4, "T": 3, "W": 1, "I": 4, "A": 1, "Ld": 4 },
+          "specialRules": ["Fear", "Immune to Psychology", "Immune to Poison", "No Pain", "Charge"],
+          "maxGroupSize": 5
+        }
+      ],
+      "equipmentAccess": {
+        "heroes": ["hand_to_hand", "missiles", "armour"],
+        "henchmen": ["hand_to_hand"]
+      }
+    },
+    {
+      "id": "cult_of_the_possessed",
+      "name": "Cult of the Possessed",
+      "source": "Core",
+      "description": "Chaos worshippers drawn to Mordheim by the power of the wyrdstone.",
+      "startingGold": 500,
+      "maxWarband": 15,
+      "alignment": "Chaos",
+      "heroes": [
+        {
+          "type": "magister",
+          "name": "Magister",
+          "max": 1,
+          "required": true,
+          "cost": 70,
+          "stats": { "M": 4, "WS": 4, "BS": 4, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 8 },
+          "specialRules": ["Leader", "Wizard"],
+          "startingExp": 20,
+          "skillAccess": ["combat", "academic", "speed"]
+        },
+        {
+          "type": "possessed",
+          "name": "Possessed",
+          "max": 2,
+          "required": false,
+          "cost": 90,
+          "stats": { "M": 5, "WS": 4, "BS": 0, "S": 4, "T": 4, "W": 2, "I": 4, "A": 2, "Ld": 7 },
+          "specialRules": ["Fear", "Mutations"],
+          "startingExp": 8,
+          "skillAccess": ["combat", "strength", "speed"]
+        },
+        {
+          "type": "mutant",
+          "name": "Mutant",
+          "max": 2,
+          "required": false,
+          "cost": 25,
+          "stats": { "M": 4, "WS": 3, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": ["Mutations"],
+          "startingExp": 0,
+          "skillAccess": ["combat", "shooting", "strength", "speed"]
+        }
+      ],
+      "henchmen": [
+        {
+          "type": "brethren",
+          "name": "Brethren",
+          "cost": 25,
+          "stats": { "M": 4, "WS": 3, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": [],
+          "maxGroupSize": 5
+        },
+        {
+          "type": "darksouls",
+          "name": "Darksouls",
+          "cost": 35,
+          "stats": { "M": 4, "WS": 4, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": ["Crazed"],
+          "maxGroupSize": 5
+        },
+        {
+          "type": "beastman",
+          "name": "Beastman",
+          "cost": 45,
+          "stats": { "M": 4, "WS": 4, "BS": 3, "S": 3, "T": 4, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+          "specialRules": [],
+          "maxGroupSize": 5
+        }
+      ],
+      "equipmentAccess": {
+        "heroes": ["hand_to_hand", "armour"],
+        "henchmen": ["hand_to_hand", "armour"]
+      }
+    },
+    {
+      "id": "skaven",
+      "name": "Skaven",
+      "source": "Core",
+      "description": "Ratmen from beneath the earth, seeking wyrdstone for their vile experiments.",
+      "startingGold": 500,
+      "maxWarband": 15,
+      "alignment": "Skaven",
+      "heroes": [
+        {
+          "type": "assassin_adept",
+          "name": "Assassin Adept",
+          "max": 1,
+          "required": true,
+          "cost": 60,
+          "stats": { "M": 5, "WS": 4, "BS": 4, "S": 3, "T": 3, "W": 1, "I": 5, "A": 1, "Ld": 7 },
+          "specialRules": ["Leader"],
+          "startingExp": 20,
+          "skillAccess": ["combat", "shooting", "academic", "speed"]
+        },
+        {
+          "type": "eshin_sorcerer",
+          "name": "Eshin Sorcerer",
+          "max": 1,
+          "required": false,
+          "cost": 45,
+          "stats": { "M": 5, "WS": 3, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 4, "A": 1, "Ld": 6 },
+          "specialRules": ["Wizard"],
+          "startingExp": 8,
+          "skillAccess": ["academic", "speed"]
+        },
+        {
+          "type": "black_skaven",
+          "name": "Black Skaven",
+          "max": 2,
+          "required": false,
+          "cost": 40,
+          "stats": { "M": 6, "WS": 4, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 4, "A": 1, "Ld": 6 },
+          "specialRules": [],
+          "startingExp": 8,
+          "skillAccess": ["combat", "shooting", "speed"]
+        },
+        {
+          "type": "night_runner",
+          "name": "Night Runner",
+          "max": 2,
+          "required": false,
+          "cost": 20,
+          "stats": { "M": 6, "WS": 3, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 4, "A": 1, "Ld": 5 },
+          "specialRules": [],
+          "startingExp": 0,
+          "skillAccess": ["combat", "shooting", "speed"]
+        }
+      ],
+      "henchmen": [
+        {
+          "type": "verminkin",
+          "name": "Verminkin",
+          "cost": 20,
+          "stats": { "M": 5, "WS": 3, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 4, "A": 1, "Ld": 5 },
+          "specialRules": [],
+          "maxGroupSize": 5
+        },
+        {
+          "type": "giant_rat",
+          "name": "Giant Rat",
+          "cost": 15,
+          "stats": { "M": 6, "WS": 2, "BS": 0, "S": 3, "T": 3, "W": 1, "I": 4, "A": 1, "Ld": 4 },
+          "specialRules": ["Animal"],
+          "maxGroupSize": 5
+        },
+        {
+          "type": "rat_ogre",
+          "name": "Rat Ogre",
+          "cost": 210,
+          "stats": { "M": 6, "WS": 3, "BS": 0, "S": 5, "T": 5, "W": 3, "I": 4, "A": 3, "Ld": 4 },
+          "specialRules": ["Fear", "Large Target", "Stupidity"],
+          "maxGroupSize": 1
+        }
+      ],
+      "equipmentAccess": {
+        "heroes": ["hand_to_hand", "missiles", "armour"],
+        "henchmen": ["hand_to_hand", "missiles"]
+      }
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,273 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mordheim Roster Manager</title>
+  <link rel="stylesheet" href="css/style.css">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9760;</text></svg>">
+</head>
+<body>
+
+  <!-- ===== HEADER ===== -->
+  <header class="app-header">
+    <div style="display:flex; align-items:center; gap:0.8rem;">
+      <button id="btn-back" class="btn btn-sm hidden" onclick="UI.goBack()">&#8592; Back</button>
+      <div class="app-title">
+        <span class="skull-icon">&#9760;</span>
+        MORDHEIM ROSTER
+      </div>
+    </div>
+    <div class="header-actions">
+      <button class="btn btn-sm" onclick="UI.importRoster()">Import</button>
+      <button class="btn btn-sm btn-primary" onclick="UI.openCreateModal()">+ New Warband</button>
+    </div>
+  </header>
+
+  <div class="app-container">
+
+    <!-- ===== ROSTER LIST VIEW ===== -->
+    <div id="roster-list" class="view active">
+      <div class="roster-list-header">
+        <h2>Your Warbands</h2>
+      </div>
+      <div id="roster-grid" class="roster-grid"></div>
+    </div>
+
+    <!-- ===== ROSTER EDITOR VIEW ===== -->
+    <div id="roster-editor" class="view">
+      <!-- Roster Header -->
+      <div class="roster-header">
+        <div class="roster-info">
+          <input type="text" id="editor-roster-name" class="inline-edit" style="font-size:1.3rem; color:var(--accent); font-weight:700;">
+          <div id="editor-warband-type" class="warband-type"></div>
+        </div>
+        <div class="roster-summary">
+          <div class="summary-stat">
+            <div class="label">Members</div>
+            <div class="value" id="summary-members">0</div>
+          </div>
+          <div class="summary-stat">
+            <div class="label">Rating</div>
+            <div class="value" id="summary-rating">0</div>
+          </div>
+          <div class="summary-stat">
+            <div class="label">Treasury</div>
+            <div class="value gold" id="summary-gold">0</div>
+          </div>
+          <div class="summary-stat">
+            <div class="label">Spent</div>
+            <div class="value" id="summary-spent">0</div>
+          </div>
+          <div class="summary-stat">
+            <div class="label">Battles</div>
+            <div class="value" id="summary-battles">0</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Tabs -->
+      <div class="tab-bar">
+        <button class="tab-btn active" data-tab="warriors" onclick="UI.switchTab('warriors')">Warriors</button>
+        <button class="tab-btn" data-tab="progress" onclick="UI.switchTab('progress')">Progress & Campaign</button>
+      </div>
+
+      <!-- Warriors Tab -->
+      <div id="tab-warriors" class="tab-content active">
+        <!-- Heroes Section -->
+        <div class="section-panel" id="heroes-section">
+          <div class="section-header" onclick="UI.toggleSection('heroes-section')">
+            <h3><span class="toggle-icon">&#9660;</span> Heroes</h3>
+            <div id="hero-add-buttons" style="display:flex; gap:0.3rem; flex-wrap:wrap;"></div>
+          </div>
+          <div class="section-content" id="heroes-content"></div>
+        </div>
+
+        <!-- Henchmen Section -->
+        <div class="section-panel" id="henchmen-section">
+          <div class="section-header" onclick="UI.toggleSection('henchmen-section')">
+            <h3><span class="toggle-icon">&#9660;</span> Henchmen</h3>
+            <div id="henchmen-add-buttons" style="display:flex; gap:0.3rem; flex-wrap:wrap;"></div>
+          </div>
+          <div class="section-content" id="henchmen-content"></div>
+        </div>
+      </div>
+
+      <!-- Progress Tab -->
+      <div id="tab-progress" class="tab-content">
+
+        <!-- Warband Rating -->
+        <div class="rating-display">
+          <div class="rating-label">Warband Rating</div>
+          <div class="rating-value" id="progress-rating">0</div>
+        </div>
+
+        <!-- Treasury -->
+        <div class="section-panel">
+          <div class="section-header">
+            <h3>Treasury & Resources</h3>
+          </div>
+          <div class="section-content">
+            <div class="treasury-section">
+              <div class="treasury-item">
+                <div class="treasury-label">Gold Crowns</div>
+                <div class="treasury-inline mt-1">
+                  <input type="number" id="gold-input" class="form-control" style="width:100px;" value="0" onchange="UI.updateGold()">
+                  <span class="text-accent">gc</span>
+                </div>
+              </div>
+              <div class="treasury-item">
+                <div class="treasury-label">Wyrdstone Shards</div>
+                <div class="treasury-inline mt-1">
+                  <input type="number" id="wyrdstone-input" class="form-control" style="width:100px;" value="0" onchange="UI.updateWyrdstone()">
+                  <span class="text-accent">shards</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Battle Log -->
+        <div class="section-panel mt-2">
+          <div class="section-header">
+            <h3>Battle Log</h3>
+          </div>
+          <div class="section-content">
+            <div style="display:flex; gap:0.5rem; margin-bottom:1rem; flex-wrap:wrap;">
+              <select id="battle-result-input" class="form-control" style="flex:1; min-width:150px;">
+                <option value="">-- Result --</option>
+                <option value="Victory">Victory</option>
+                <option value="Defeat">Defeat</option>
+                <option value="Draw">Draw</option>
+                <option value="Voluntary Rout">Voluntary Rout</option>
+              </select>
+              <input type="text" id="battle-notes-input" class="form-control" placeholder="Notes (opponent, scenario...)" style="flex:2; min-width:200px;">
+              <button class="btn btn-primary" onclick="UI.addBattle()">Log Battle</button>
+            </div>
+            <div id="battle-log-entries"></div>
+          </div>
+        </div>
+
+        <!-- Notes -->
+        <div class="section-panel mt-2">
+          <div class="section-header">
+            <h3>Campaign Notes</h3>
+          </div>
+          <div class="section-content">
+            <textarea id="roster-notes" class="notes-area" placeholder="Write campaign notes, strategy, or lore here..." onchange="UI.updateNotes()"></textarea>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+  </div>
+
+  <!-- ===== CREATE ROSTER MODAL ===== -->
+  <div id="create-modal" class="modal-overlay">
+    <div class="modal">
+      <div class="modal-header">
+        <h3>Create Warband</h3>
+        <button class="btn btn-icon" onclick="UI.closeCreateModal()">&#10005;</button>
+      </div>
+      <div class="modal-body">
+        <div class="form-group">
+          <label>Warband Name</label>
+          <input type="text" id="create-roster-name" class="form-control" placeholder="e.g. The Crimson Blades">
+        </div>
+        <div class="form-group">
+          <label>Warband Type</label>
+          <select id="create-warband-select" class="form-control" onchange="UI.onWarbandSelectChange()">
+            <option value="">-- Select Warband --</option>
+          </select>
+        </div>
+        <p id="warband-description" class="text-dim" style="font-size:0.85rem; min-height:2rem;"></p>
+      </div>
+      <div class="modal-footer">
+        <button class="btn" onclick="UI.closeCreateModal()">Cancel</button>
+        <button class="btn btn-primary" onclick="UI.submitCreateRoster()">Create</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ===== EQUIPMENT MODAL ===== -->
+  <div id="equipment-modal" class="modal-overlay">
+    <div class="modal">
+      <div class="modal-header">
+        <h3>Add Equipment</h3>
+        <button class="btn btn-icon" onclick="UI.closeModal('equipment-modal')">&#10005;</button>
+      </div>
+      <div class="modal-body" id="equipment-modal-body"></div>
+    </div>
+  </div>
+
+  <!-- ===== SKILL MODAL ===== -->
+  <div id="skill-modal" class="modal-overlay">
+    <div class="modal">
+      <div class="modal-header">
+        <h3>Add Skill</h3>
+        <button class="btn btn-icon" onclick="UI.closeModal('skill-modal')">&#10005;</button>
+      </div>
+      <div class="modal-body" id="skill-modal-body"></div>
+    </div>
+  </div>
+
+  <!-- ===== INJURY MODAL ===== -->
+  <div id="injury-modal" class="modal-overlay">
+    <div class="modal">
+      <div class="modal-header">
+        <h3>Record Injury</h3>
+        <button class="btn btn-icon" onclick="UI.closeModal('injury-modal')">&#10005;</button>
+      </div>
+      <div class="modal-body" id="injury-modal-body"></div>
+    </div>
+  </div>
+
+  <!-- ===== STAT ADJUST MODAL ===== -->
+  <div id="stat-modal" class="modal-overlay">
+    <div class="modal">
+      <div class="modal-header">
+        <h3>Adjust Stats</h3>
+        <button class="btn btn-icon" onclick="UI.closeModal('stat-modal')">&#10005;</button>
+      </div>
+      <div class="modal-body" id="stat-modal-body"></div>
+    </div>
+  </div>
+
+  <!-- ===== CONFIRM DIALOG ===== -->
+  <div id="confirm-overlay" class="confirm-overlay">
+    <div class="confirm-box">
+      <h4>Confirm</h4>
+      <p id="confirm-message"></p>
+      <div class="confirm-actions">
+        <button class="btn" id="confirm-no">Cancel</button>
+        <button class="btn btn-danger" id="confirm-yes">Delete</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ===== TOAST CONTAINER ===== -->
+  <div id="toast-container" class="toast-container"></div>
+
+  <!-- ===== SCRIPTS ===== -->
+  <script src="js/data.js"></script>
+  <script src="js/storage.js"></script>
+  <script src="js/roster.js"></script>
+  <script src="js/ui.js"></script>
+  <script>
+    // Boot the app
+    (async function() {
+      try {
+        await DataService.loadAll();
+        UI.init();
+      } catch (err) {
+        console.error('Failed to initialize:', err);
+        document.body.innerHTML = '<div style="padding:2rem; color:#c9a84c; text-align:center;">' +
+          '<h2>Failed to Load</h2><p>' + err.message + '</p>' +
+          '<p style="color:#9998a5; margin-top:1rem;">Make sure you are running this from a web server (not file://). Use: <code>python3 -m http.server</code></p></div>';
+      }
+    })();
+  </script>
+
+</body>
+</html>

--- a/js/data.js
+++ b/js/data.js
@@ -1,0 +1,75 @@
+// Data loading module - loads JSON data files
+const DataService = {
+  warbands: null,
+  equipment: null,
+  skills: null,
+  injuries: null,
+  advancement: null,
+
+  async loadAll() {
+    const [warbands, equipment, skills, injuries, advancement] = await Promise.all([
+      this.fetchJSON('data/warbands.json'),
+      this.fetchJSON('data/equipment.json'),
+      this.fetchJSON('data/skills.json'),
+      this.fetchJSON('data/injuries.json'),
+      this.fetchJSON('data/advancement.json'),
+    ]);
+
+    this.warbands = warbands.warbands;
+    this.equipment = equipment.categories;
+    this.skills = skills.skillCategories;
+    this.injuries = injuries;
+    this.advancement = advancement;
+  },
+
+  async fetchJSON(path) {
+    const resp = await fetch(path);
+    if (!resp.ok) throw new Error(`Failed to load ${path}`);
+    return resp.json();
+  },
+
+  getWarband(id) {
+    return this.warbands.find(w => w.id === id);
+  },
+
+  getEquipmentItem(itemId) {
+    for (const cat of Object.values(this.equipment)) {
+      const item = cat.items.find(i => i.id === itemId);
+      if (item) return item;
+    }
+    return null;
+  },
+
+  getEquipmentByCategory(categoryId) {
+    return this.equipment[categoryId]?.items || [];
+  },
+
+  getAllEquipment() {
+    const all = [];
+    for (const cat of Object.values(this.equipment)) {
+      all.push(...cat.items);
+    }
+    return all;
+  },
+
+  getSkill(skillId) {
+    for (const cat of Object.values(this.skills)) {
+      const skill = cat.skills.find(s => s.id === skillId);
+      if (skill) return skill;
+    }
+    return null;
+  },
+
+  getSkillsByCategory(categoryId) {
+    return this.skills[categoryId]?.skills || [];
+  },
+
+  getExpThreshold(level) {
+    const thresholds = this.advancement.heroAdvancement.expThresholds;
+    return level < thresholds.length ? thresholds[level] : thresholds[thresholds.length - 1] + (level - thresholds.length + 1) * 10;
+  },
+
+  getMaxStat(stat) {
+    return this.advancement.maxStats[stat] || 10;
+  }
+};

--- a/js/roster.js
+++ b/js/roster.js
@@ -1,0 +1,167 @@
+// Roster model and logic
+const RosterModel = {
+
+  createRoster(name, warbandId) {
+    const warband = DataService.getWarband(warbandId);
+    if (!warband) throw new Error('Unknown warband: ' + warbandId);
+
+    return {
+      id: Storage.generateId(),
+      name,
+      warbandId,
+      gold: warband.startingGold,
+      wyrdstone: 0,
+      heroes: [],
+      henchmen: [],
+      battleLog: [],
+      notes: '',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+  },
+
+  createWarrior(templateType, isHero, warband) {
+    const templates = isHero ? warband.heroes : warband.henchmen;
+    const template = templates.find(t => t.type === templateType);
+    if (!template) return null;
+
+    const warrior = {
+      id: Storage.generateId(),
+      type: template.type,
+      typeName: template.name,
+      name: template.name,
+      isHero,
+      stats: { ...template.stats },
+      baseStats: { ...template.stats },
+      equipment: [],
+      skills: [],
+      injuries: [],
+      experience: isHero ? (template.startingExp || 0) : 0,
+      advancementCount: 0,
+      missNextGame: false,
+      cost: template.cost,
+      specialRules: [...(template.specialRules || [])],
+    };
+
+    if (!isHero) {
+      warrior.groupSize = 1;
+    }
+
+    return warrior;
+  },
+
+  addEquipment(warrior, itemId) {
+    const item = DataService.getEquipmentItem(itemId);
+    if (!item) return false;
+    warrior.equipment.push({ id: itemId, name: item.name });
+    return true;
+  },
+
+  removeEquipment(warrior, index) {
+    warrior.equipment.splice(index, 1);
+  },
+
+  addSkill(warrior, skillId) {
+    const skill = DataService.getSkill(skillId);
+    if (!skill) return false;
+    if (warrior.skills.find(s => s.id === skillId)) return false;
+    warrior.skills.push({ id: skillId, name: skill.name });
+    return true;
+  },
+
+  removeSkill(warrior, index) {
+    warrior.skills.splice(index, 1);
+  },
+
+  addInjury(warrior, injuryName) {
+    warrior.injuries.push({ name: injuryName, gameNumber: 0 });
+  },
+
+  removeInjury(warrior, index) {
+    warrior.injuries.splice(index, 1);
+  },
+
+  modifyStat(warrior, stat, delta) {
+    const maxVal = DataService.getMaxStat(stat);
+    const newVal = warrior.stats[stat] + delta;
+    if (newVal < 0 || newVal > maxVal) return false;
+    warrior.stats[stat] = newVal;
+    return true;
+  },
+
+  addExperience(warrior, amount) {
+    warrior.experience += amount;
+  },
+
+  getHeroLevel(experience) {
+    const thresholds = DataService.advancement.heroAdvancement.expThresholds;
+    let level = 0;
+    for (let i = 0; i < thresholds.length; i++) {
+      if (experience >= thresholds[i]) level = i + 1;
+      else break;
+    }
+    return level;
+  },
+
+  getNextThreshold(experience) {
+    const thresholds = DataService.advancement.heroAdvancement.expThresholds;
+    for (const t of thresholds) {
+      if (experience < t) return t;
+    }
+    return experience + 10;
+  },
+
+  calculateWarbandRating(roster) {
+    const warband = DataService.getWarband(roster.warbandId);
+    let rating = 0;
+    // heroes: 5 per experience point + 5 base
+    for (const h of roster.heroes) {
+      rating += 5 + (h.experience * 1);
+      rating += h.equipment.length * 5;
+    }
+    // henchmen: 5 per member
+    for (const hg of roster.henchmen) {
+      const groupCount = hg.groupSize || 1;
+      rating += groupCount * 5;
+      rating += hg.experience * groupCount;
+    }
+    return rating;
+  },
+
+  calculateTotalCost(roster) {
+    let total = 0;
+    for (const h of roster.heroes) {
+      total += h.cost;
+      for (const eq of h.equipment) {
+        const item = DataService.getEquipmentItem(eq.id);
+        if (item) total += item.cost;
+      }
+    }
+    for (const hg of roster.henchmen) {
+      const groupCount = hg.groupSize || 1;
+      total += hg.cost * groupCount;
+      for (const eq of hg.equipment) {
+        const item = DataService.getEquipmentItem(eq.id);
+        if (item) total += item.cost * groupCount;
+      }
+    }
+    return total;
+  },
+
+  getMemberCount(roster) {
+    let count = roster.heroes.length;
+    for (const hg of roster.henchmen) {
+      count += hg.groupSize || 1;
+    }
+    return count;
+  },
+
+  addBattle(roster, result, notes) {
+    roster.battleLog.push({
+      number: roster.battleLog.length + 1,
+      result,
+      notes: notes || '',
+      date: new Date().toISOString(),
+    });
+  }
+};

--- a/js/storage.js
+++ b/js/storage.js
@@ -1,0 +1,53 @@
+// LocalStorage persistence module
+const Storage = {
+  ROSTERS_KEY: 'mordheim_rosters',
+
+  getAllRosters() {
+    const data = localStorage.getItem(this.ROSTERS_KEY);
+    return data ? JSON.parse(data) : [];
+  },
+
+  saveAllRosters(rosters) {
+    localStorage.setItem(this.ROSTERS_KEY, JSON.stringify(rosters));
+  },
+
+  getRoster(id) {
+    return this.getAllRosters().find(r => r.id === id) || null;
+  },
+
+  saveRoster(roster) {
+    const rosters = this.getAllRosters();
+    const idx = rosters.findIndex(r => r.id === roster.id);
+    if (idx >= 0) {
+      rosters[idx] = roster;
+    } else {
+      rosters.push(roster);
+    }
+    this.saveAllRosters(rosters);
+  },
+
+  deleteRoster(id) {
+    const rosters = this.getAllRosters().filter(r => r.id !== id);
+    this.saveAllRosters(rosters);
+  },
+
+  exportRoster(id) {
+    const roster = this.getRoster(id);
+    if (!roster) return null;
+    return JSON.stringify(roster, null, 2);
+  },
+
+  importRoster(jsonString) {
+    const roster = JSON.parse(jsonString);
+    if (!roster.id || !roster.name || !roster.warbandId) {
+      throw new Error('Invalid roster format');
+    }
+    roster.id = this.generateId(); // assign new id to avoid conflicts
+    this.saveRoster(roster);
+    return roster;
+  },
+
+  generateId() {
+    return 'r_' + Date.now().toString(36) + '_' + Math.random().toString(36).substr(2, 6);
+  }
+};

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,737 @@
+// UI rendering and event handling
+const UI = {
+  currentRoster: null,
+
+  init() {
+    this.bindGlobalEvents();
+    this.showView('roster-list');
+    this.renderRosterList();
+  },
+
+  // === VIEWS ===
+  showView(viewId) {
+    document.querySelectorAll('.view').forEach(v => v.classList.remove('active'));
+    const view = document.getElementById(viewId);
+    if (view) view.classList.add('active');
+
+    // Update header
+    const backBtn = document.getElementById('btn-back');
+    if (viewId === 'roster-list') {
+      backBtn.classList.add('hidden');
+    } else {
+      backBtn.classList.remove('hidden');
+    }
+  },
+
+  // === ROSTER LIST ===
+  renderRosterList() {
+    const rosters = Storage.getAllRosters();
+    const grid = document.getElementById('roster-grid');
+
+    if (rosters.length === 0) {
+      grid.innerHTML = `
+        <div class="empty-state" style="grid-column: 1 / -1;">
+          <h3>No Warbands Yet</h3>
+          <p>Create your first warband to begin your campaign in the City of the Damned.</p>
+          <button class="btn btn-primary" onclick="UI.openCreateModal()">Create Warband</button>
+        </div>
+      `;
+      return;
+    }
+
+    grid.innerHTML = rosters.map(r => {
+      const warband = DataService.getWarband(r.warbandId);
+      const memberCount = RosterModel.getMemberCount(r);
+      const rating = RosterModel.calculateWarbandRating(r);
+      return `
+        <div class="roster-card" onclick="UI.openRoster('${r.id}')">
+          <div class="roster-card-name">${this.esc(r.name)}</div>
+          <div class="roster-card-warband">${warband ? warband.name : r.warbandId}</div>
+          <div class="roster-card-stats">
+            <div class="roster-card-stat">Members: <strong>${memberCount}</strong></div>
+            <div class="roster-card-stat">Rating: <strong>${rating}</strong></div>
+            <div class="roster-card-stat">Gold: <strong>${r.gold}</strong></div>
+            <div class="roster-card-stat">Battles: <strong>${r.battleLog.length}</strong></div>
+          </div>
+          <div class="roster-card-actions" onclick="event.stopPropagation()">
+            <button class="btn btn-sm" onclick="UI.exportRoster('${r.id}')">Export</button>
+            <button class="btn btn-sm btn-danger" onclick="UI.confirmDeleteRoster('${r.id}')">Delete</button>
+          </div>
+        </div>
+      `;
+    }).join('');
+  },
+
+  // === CREATE ROSTER MODAL ===
+  openCreateModal() {
+    const modal = document.getElementById('create-modal');
+    const select = document.getElementById('create-warband-select');
+    select.innerHTML = '<option value="">-- Select Warband --</option>' +
+      DataService.warbands.map(w => `<option value="${w.id}">${w.name} (${w.source})</option>`).join('');
+    document.getElementById('create-roster-name').value = '';
+    document.getElementById('warband-description').textContent = '';
+    modal.classList.add('active');
+  },
+
+  closeCreateModal() {
+    document.getElementById('create-modal').classList.remove('active');
+  },
+
+  onWarbandSelectChange() {
+    const id = document.getElementById('create-warband-select').value;
+    const desc = document.getElementById('warband-description');
+    const warband = DataService.getWarband(id);
+    desc.textContent = warband ? `${warband.description} Starting gold: ${warband.startingGold} gc.` : '';
+  },
+
+  submitCreateRoster() {
+    const name = document.getElementById('create-roster-name').value.trim();
+    const warbandId = document.getElementById('create-warband-select').value;
+    if (!name) return this.toast('Enter a warband name.', 'error');
+    if (!warbandId) return this.toast('Select a warband type.', 'error');
+
+    const roster = RosterModel.createRoster(name, warbandId);
+    Storage.saveRoster(roster);
+    this.closeCreateModal();
+    this.renderRosterList();
+    this.toast(`"${name}" warband created!`, 'success');
+  },
+
+  // === ROSTER EDITOR ===
+  openRoster(id) {
+    const roster = Storage.getRoster(id);
+    if (!roster) return this.toast('Roster not found.', 'error');
+    this.currentRoster = roster;
+    this.showView('roster-editor');
+    this.renderRosterEditor();
+  },
+
+  saveCurrentRoster() {
+    if (!this.currentRoster) return;
+    this.currentRoster.updatedAt = new Date().toISOString();
+    Storage.saveRoster(this.currentRoster);
+  },
+
+  renderRosterEditor() {
+    const r = this.currentRoster;
+    if (!r) return;
+    const warband = DataService.getWarband(r.warbandId);
+    const memberCount = RosterModel.getMemberCount(r);
+    const rating = RosterModel.calculateWarbandRating(r);
+    const totalSpent = RosterModel.calculateTotalCost(r);
+
+    // Header
+    document.getElementById('editor-roster-name').value = r.name;
+    document.getElementById('editor-warband-type').textContent = warband ? warband.name : r.warbandId;
+
+    // Summary
+    document.getElementById('summary-members').textContent = `${memberCount} / ${warband.maxWarband}`;
+    document.getElementById('summary-rating').textContent = rating;
+    document.getElementById('summary-gold').textContent = r.gold + ' gc';
+    document.getElementById('summary-spent').textContent = totalSpent + ' gc';
+    document.getElementById('summary-battles').textContent = r.battleLog.length;
+
+    // Tab contents
+    this.renderWarriorsTab();
+    this.renderProgressTab();
+  },
+
+  // === WARRIORS TAB ===
+  renderWarriorsTab() {
+    const r = this.currentRoster;
+    const warband = DataService.getWarband(r.warbandId);
+
+    // Heroes section
+    const heroesContent = document.getElementById('heroes-content');
+    if (r.heroes.length === 0) {
+      heroesContent.innerHTML = '<p class="text-dim" style="padding: 0.5rem 0;">No heroes recruited yet.</p>';
+    } else {
+      heroesContent.innerHTML = r.heroes.map((h, idx) => this.renderWarriorCard(h, idx, true)).join('');
+    }
+
+    // Hero add buttons
+    const heroAddContainer = document.getElementById('hero-add-buttons');
+    heroAddContainer.innerHTML = warband.heroes.map(ht => {
+      const currentCount = r.heroes.filter(h => h.type === ht.type).length;
+      const disabled = currentCount >= ht.max ? 'disabled' : '';
+      return `<button class="btn btn-sm btn-primary" ${disabled} onclick="UI.addWarrior('${ht.type}', true)">${ht.name} (${ht.cost} gc)</button>`;
+    }).join(' ');
+
+    // Henchmen section
+    const henchmenContent = document.getElementById('henchmen-content');
+    if (r.henchmen.length === 0) {
+      henchmenContent.innerHTML = '<p class="text-dim" style="padding: 0.5rem 0;">No henchmen recruited yet.</p>';
+    } else {
+      henchmenContent.innerHTML = r.henchmen.map((h, idx) => this.renderWarriorCard(h, idx, false)).join('');
+    }
+
+    // Henchmen add buttons
+    const henchAddContainer = document.getElementById('henchmen-add-buttons');
+    henchAddContainer.innerHTML = warband.henchmen.map(ht => {
+      return `<button class="btn btn-sm btn-primary" onclick="UI.addWarrior('${ht.type}', false)">${ht.name} (${ht.cost} gc)</button>`;
+    }).join(' ');
+  },
+
+  renderWarriorCard(warrior, index, isHero) {
+    const eqCost = warrior.equipment.reduce((sum, eq) => {
+      const item = DataService.getEquipmentItem(eq.id);
+      return sum + (item ? item.cost : 0);
+    }, 0);
+    const totalCost = warrior.cost + eqCost;
+
+    // Experience bar for heroes
+    let expBar = '';
+    if (isHero) {
+      const level = RosterModel.getHeroLevel(warrior.experience);
+      const nextThreshold = RosterModel.getNextThreshold(warrior.experience);
+      const prevThreshold = level > 0 ? DataService.advancement.heroAdvancement.expThresholds[level - 1] : 0;
+      const progress = nextThreshold > prevThreshold ? ((warrior.experience - prevThreshold) / (nextThreshold - prevThreshold)) * 100 : 100;
+      expBar = `
+        <div class="exp-bar-container">
+          <div class="exp-bar-label">
+            <span>EXP: ${warrior.experience} (Level ${level})</span>
+            <span>Next: ${nextThreshold}</span>
+          </div>
+          <div class="exp-bar"><div class="exp-bar-fill" style="width:${Math.min(progress, 100)}%"></div></div>
+        </div>
+      `;
+    } else {
+      expBar = `
+        <div class="exp-bar-container">
+          <div class="exp-bar-label"><span>EXP: ${warrior.experience}</span><span>Group Size: ${warrior.groupSize || 1}</span></div>
+        </div>
+      `;
+    }
+
+    const listType = isHero ? 'heroes' : 'henchmen';
+
+    return `
+      <div class="warrior-card" id="warrior-${warrior.id}">
+        <div class="warrior-card-header" onclick="UI.toggleWarriorCard('${warrior.id}')">
+          <div>
+            <span class="warrior-name">${this.esc(warrior.name)}</span>
+            <span class="warrior-type">${warrior.typeName}</span>
+          </div>
+          <span class="warrior-cost">${totalCost} gc</span>
+        </div>
+        <div class="warrior-card-body" id="warrior-body-${warrior.id}">
+          <div class="form-group">
+            <input type="text" class="inline-edit" value="${this.esc(warrior.name)}"
+              onchange="UI.renameWarrior('${listType}', ${index}, this.value)" style="font-weight:600; font-size: 0.95rem; width: 100%;">
+          </div>
+
+          <div class="stat-line">
+            ${['M','WS','BS','S','T','W','I','A','Ld'].map(stat => {
+              const isModified = warrior.stats[stat] !== warrior.baseStats[stat];
+              return `
+                <div class="stat-cell">
+                  <div class="stat-label">${stat}</div>
+                  <div class="stat-value${isModified ? ' modified' : ''}">${warrior.stats[stat]}</div>
+                </div>
+              `;
+            }).join('')}
+          </div>
+
+          ${expBar}
+
+          ${warrior.specialRules.length > 0 ? `
+          <div class="tag-section mt-1">
+            <div class="tag-section-label">Special Rules</div>
+            <div class="tag-list">${warrior.specialRules.map(sr => `<span class="tag">${sr}</span>`).join('')}</div>
+          </div>` : ''}
+
+          <div class="tag-section mt-1">
+            <div class="tag-section-label">Equipment</div>
+            <div class="tag-list">
+              ${warrior.equipment.map((eq, eqIdx) => `
+                <span class="tag equipment">${eq.name} <span class="tag-remove" onclick="UI.removeEquipment('${listType}', ${index}, ${eqIdx})">x</span></span>
+              `).join('')}
+              <button class="btn btn-sm" onclick="UI.openEquipmentModal('${listType}', ${index})">+ Add</button>
+            </div>
+          </div>
+
+          <div class="tag-section mt-1">
+            <div class="tag-section-label">Skills</div>
+            <div class="tag-list">
+              ${warrior.skills.map((sk, skIdx) => `
+                <span class="tag skill">${sk.name} <span class="tag-remove" onclick="UI.removeSkill('${listType}', ${index}, ${skIdx})">x</span></span>
+              `).join('')}
+              ${isHero ? `<button class="btn btn-sm" onclick="UI.openSkillModal('${listType}', ${index})">+ Add</button>` : ''}
+            </div>
+          </div>
+
+          <div class="tag-section mt-1">
+            <div class="tag-section-label">Injuries</div>
+            <div class="tag-list">
+              ${warrior.injuries.map((inj, injIdx) => `
+                <span class="tag injury">${inj.name} <span class="tag-remove" onclick="UI.removeInjury('${listType}', ${index}, ${injIdx})">x</span></span>
+              `).join('')}
+              <button class="btn btn-sm" onclick="UI.openInjuryModal('${listType}', ${index})">+ Add</button>
+            </div>
+          </div>
+
+          <div class="warrior-actions">
+            <button class="btn btn-sm" onclick="UI.adjustExp('${listType}', ${index}, 1)">+1 XP</button>
+            <button class="btn btn-sm" onclick="UI.adjustExp('${listType}', ${index}, -1)">-1 XP</button>
+            <button class="btn btn-sm" onclick="UI.openStatAdjust('${listType}', ${index})">Adjust Stats</button>
+            ${!isHero ? `
+              <button class="btn btn-sm" onclick="UI.adjustGroupSize(${index}, 1)">+1 Member</button>
+              <button class="btn btn-sm" onclick="UI.adjustGroupSize(${index}, -1)">-1 Member</button>
+            ` : ''}
+            <button class="btn btn-sm btn-danger" onclick="UI.removeWarrior('${listType}', ${index})">Remove</button>
+          </div>
+        </div>
+      </div>
+    `;
+  },
+
+  toggleWarriorCard(id) {
+    const body = document.getElementById('warrior-body-' + id);
+    if (body) body.classList.toggle('collapsed');
+  },
+
+  // === ADD WARRIOR ===
+  addWarrior(type, isHero) {
+    const r = this.currentRoster;
+    const warband = DataService.getWarband(r.warbandId);
+
+    // Validate limits
+    if (isHero) {
+      const template = warband.heroes.find(h => h.type === type);
+      const currentCount = r.heroes.filter(h => h.type === type).length;
+      if (currentCount >= template.max) {
+        return this.toast(`Maximum ${template.name}s reached (${template.max}).`, 'error');
+      }
+    }
+
+    const memberCount = RosterModel.getMemberCount(r);
+    if (memberCount >= warband.maxWarband) {
+      return this.toast(`Warband is full (${warband.maxWarband} members).`, 'error');
+    }
+
+    const warrior = RosterModel.createWarrior(type, isHero, warband);
+    if (!warrior) return this.toast('Unknown warrior type.', 'error');
+
+    if (isHero) {
+      r.heroes.push(warrior);
+    } else {
+      r.henchmen.push(warrior);
+    }
+
+    this.saveCurrentRoster();
+    this.renderRosterEditor();
+    this.toast(`${warrior.typeName} added.`, 'success');
+  },
+
+  removeWarrior(listType, index) {
+    const r = this.currentRoster;
+    const warrior = r[listType][index];
+    if (!warrior) return;
+    r[listType].splice(index, 1);
+    this.saveCurrentRoster();
+    this.renderRosterEditor();
+    this.toast(`${warrior.name} removed.`, 'info');
+  },
+
+  renameWarrior(listType, index, newName) {
+    const warrior = this.currentRoster[listType][index];
+    if (!warrior) return;
+    warrior.name = newName.trim() || warrior.typeName;
+    this.saveCurrentRoster();
+    // Update header name display
+    const card = document.getElementById('warrior-' + warrior.id);
+    if (card) {
+      const nameEl = card.querySelector('.warrior-name');
+      if (nameEl) nameEl.textContent = warrior.name;
+    }
+  },
+
+  // === EQUIPMENT MODAL ===
+  openEquipmentModal(listType, index) {
+    const r = this.currentRoster;
+    const warrior = r[listType][index];
+    const warband = DataService.getWarband(r.warbandId);
+
+    const accessKey = listType === 'heroes' ? 'heroes' : 'henchmen';
+    const accessibleCategories = warband.equipmentAccess[accessKey] || [];
+
+    const modal = document.getElementById('equipment-modal');
+    const body = document.getElementById('equipment-modal-body');
+
+    let html = '';
+    // Add miscellaneous always
+    const allCats = [...accessibleCategories, 'miscellaneous'];
+    for (const catId of allCats) {
+      const items = DataService.getEquipmentByCategory(catId);
+      if (items.length === 0) continue;
+      const catName = DataService.equipment[catId]?.name || catId;
+      html += `<h4 class="text-accent mb-1 mt-2" style="font-size:0.85rem; text-transform:uppercase;">${catName}</h4>`;
+      html += '<div style="display:flex; flex-wrap:wrap; gap:0.3rem;">';
+      for (const item of items) {
+        html += `<button class="btn btn-sm" onclick="UI.selectEquipment('${listType}', ${index}, '${item.id}')">${item.name} (${item.cost} gc)</button>`;
+      }
+      html += '</div>';
+    }
+
+    body.innerHTML = html;
+    modal.classList.add('active');
+  },
+
+  selectEquipment(listType, index, itemId) {
+    const warrior = this.currentRoster[listType][index];
+    if (!warrior) return;
+    RosterModel.addEquipment(warrior, itemId);
+    this.saveCurrentRoster();
+    this.renderRosterEditor();
+    document.getElementById('equipment-modal').classList.remove('active');
+    const item = DataService.getEquipmentItem(itemId);
+    this.toast(`${item.name} added to ${warrior.name}.`, 'success');
+  },
+
+  removeEquipment(listType, index, eqIndex) {
+    const warrior = this.currentRoster[listType][index];
+    if (!warrior) return;
+    RosterModel.removeEquipment(warrior, eqIndex);
+    this.saveCurrentRoster();
+    this.renderRosterEditor();
+  },
+
+  // === SKILL MODAL ===
+  openSkillModal(listType, index) {
+    const warrior = this.currentRoster[listType][index];
+    const warband = DataService.getWarband(this.currentRoster.warbandId);
+    const template = warband.heroes.find(h => h.type === warrior.type);
+    const accessCategories = template ? template.skillAccess : [];
+
+    const modal = document.getElementById('skill-modal');
+    const body = document.getElementById('skill-modal-body');
+
+    let html = '';
+    for (const catId of accessCategories) {
+      const skills = DataService.getSkillsByCategory(catId);
+      if (skills.length === 0) continue;
+      const catName = DataService.skills[catId]?.name || catId;
+      html += `<h4 class="text-accent mb-1 mt-2" style="font-size:0.85rem; text-transform:uppercase;">${catName}</h4>`;
+      for (const skill of skills) {
+        const alreadyHas = warrior.skills.find(s => s.id === skill.id);
+        const disabled = alreadyHas ? 'disabled' : '';
+        html += `<button class="btn btn-sm mb-1" ${disabled} onclick="UI.selectSkill('${listType}', ${index}, '${skill.id}')" title="${this.esc(skill.description)}">${skill.name}</button> `;
+      }
+    }
+
+    body.innerHTML = html;
+    modal.classList.add('active');
+  },
+
+  selectSkill(listType, index, skillId) {
+    const warrior = this.currentRoster[listType][index];
+    if (!warrior) return;
+    RosterModel.addSkill(warrior, skillId);
+    this.saveCurrentRoster();
+    this.renderRosterEditor();
+    document.getElementById('skill-modal').classList.remove('active');
+    const skill = DataService.getSkill(skillId);
+    this.toast(`${skill.name} learned by ${warrior.name}.`, 'success');
+  },
+
+  removeSkill(listType, index, skIndex) {
+    const warrior = this.currentRoster[listType][index];
+    if (!warrior) return;
+    RosterModel.removeSkill(warrior, skIndex);
+    this.saveCurrentRoster();
+    this.renderRosterEditor();
+  },
+
+  // === INJURY MODAL ===
+  openInjuryModal(listType, index) {
+    const warrior = this.currentRoster[listType][index];
+    const isHero = listType === 'heroes';
+    const injuryList = isHero ? DataService.injuries.heroInjuries : DataService.injuries.henchmenInjuries;
+
+    const modal = document.getElementById('injury-modal');
+    const body = document.getElementById('injury-modal-body');
+
+    let html = '<div style="display:flex; flex-direction:column; gap:0.4rem;">';
+    for (const inj of injuryList) {
+      html += `<button class="btn btn-sm" onclick="UI.selectInjury('${listType}', ${index}, '${this.esc(inj.name)}')" title="${this.esc(inj.description)}">
+        <strong>${inj.roll}</strong> - ${inj.name}
+      </button>`;
+    }
+    html += '</div>';
+    body.innerHTML = html;
+    modal.classList.add('active');
+  },
+
+  selectInjury(listType, index, injuryName) {
+    const warrior = this.currentRoster[listType][index];
+    if (!warrior) return;
+    RosterModel.addInjury(warrior, injuryName);
+    this.saveCurrentRoster();
+    this.renderRosterEditor();
+    document.getElementById('injury-modal').classList.remove('active');
+    this.toast(`${injuryName} applied to ${warrior.name}.`, 'info');
+  },
+
+  removeInjury(listType, index, injIndex) {
+    const warrior = this.currentRoster[listType][index];
+    if (!warrior) return;
+    RosterModel.removeInjury(warrior, injIndex);
+    this.saveCurrentRoster();
+    this.renderRosterEditor();
+  },
+
+  // === STAT ADJUST ===
+  openStatAdjust(listType, index) {
+    const warrior = this.currentRoster[listType][index];
+    const modal = document.getElementById('stat-modal');
+    const body = document.getElementById('stat-modal-body');
+
+    const stats = ['M','WS','BS','S','T','W','I','A','Ld'];
+    let html = '<div style="display:grid; grid-template-columns: repeat(3, 1fr); gap:0.5rem;">';
+    for (const stat of stats) {
+      html += `
+        <div style="text-align:center; background:var(--bg-input); border-radius:var(--radius); padding:0.5rem;">
+          <div style="font-size:0.7rem; color:var(--text-muted); text-transform:uppercase;">${stat}</div>
+          <div style="font-size:1.1rem; font-weight:700; color:var(--text-bright); margin:0.2rem 0;">${warrior.stats[stat]}</div>
+          <div style="display:flex; gap:0.3rem; justify-content:center;">
+            <button class="btn btn-sm" onclick="UI.modStat('${listType}', ${index}, '${stat}', -1)">-</button>
+            <button class="btn btn-sm" onclick="UI.modStat('${listType}', ${index}, '${stat}', 1)">+</button>
+          </div>
+        </div>
+      `;
+    }
+    html += '</div>';
+    body.innerHTML = html;
+    modal.classList.add('active');
+  },
+
+  modStat(listType, index, stat, delta) {
+    const warrior = this.currentRoster[listType][index];
+    if (!warrior) return;
+    if (RosterModel.modifyStat(warrior, stat, delta)) {
+      this.saveCurrentRoster();
+      this.openStatAdjust(listType, index); // re-render
+      this.renderRosterEditor();
+    } else {
+      this.toast('Stat limit reached.', 'error');
+    }
+  },
+
+  // === EXPERIENCE ===
+  adjustExp(listType, index, amount) {
+    const warrior = this.currentRoster[listType][index];
+    if (!warrior) return;
+    warrior.experience = Math.max(0, warrior.experience + amount);
+    this.saveCurrentRoster();
+    this.renderRosterEditor();
+  },
+
+  // === GROUP SIZE ===
+  adjustGroupSize(index, delta) {
+    const henchman = this.currentRoster.henchmen[index];
+    if (!henchman) return;
+    const newSize = (henchman.groupSize || 1) + delta;
+    if (newSize < 1) return this.toast('Group must have at least 1 member.', 'error');
+    if (newSize > 5) return this.toast('Maximum group size is 5.', 'error');
+    henchman.groupSize = newSize;
+    this.saveCurrentRoster();
+    this.renderRosterEditor();
+  },
+
+  // === PROGRESS TAB ===
+  renderProgressTab() {
+    const r = this.currentRoster;
+    const rating = RosterModel.calculateWarbandRating(r);
+
+    // Rating
+    document.getElementById('progress-rating').textContent = rating;
+
+    // Gold management
+    document.getElementById('gold-input').value = r.gold;
+    document.getElementById('wyrdstone-input').value = r.wyrdstone;
+
+    // Battle log
+    this.renderBattleLog();
+
+    // Notes
+    document.getElementById('roster-notes').value = r.notes || '';
+  },
+
+  renderBattleLog() {
+    const r = this.currentRoster;
+    const container = document.getElementById('battle-log-entries');
+
+    if (r.battleLog.length === 0) {
+      container.innerHTML = '<p class="text-dim">No battles fought yet.</p>';
+      return;
+    }
+
+    container.innerHTML = r.battleLog.slice().reverse().map(b => `
+      <div class="battle-log-entry">
+        <div class="battle-info">
+          <div class="battle-number">Battle #${b.number}</div>
+          <div class="battle-result">${this.esc(b.result)}</div>
+          ${b.notes ? `<div class="battle-date">${this.esc(b.notes)}</div>` : ''}
+        </div>
+        <div class="battle-date">${new Date(b.date).toLocaleDateString()}</div>
+      </div>
+    `).join('');
+  },
+
+  updateGold() {
+    const val = parseInt(document.getElementById('gold-input').value) || 0;
+    this.currentRoster.gold = val;
+    this.saveCurrentRoster();
+    document.getElementById('summary-gold').textContent = val + ' gc';
+  },
+
+  updateWyrdstone() {
+    const val = parseInt(document.getElementById('wyrdstone-input').value) || 0;
+    this.currentRoster.wyrdstone = val;
+    this.saveCurrentRoster();
+  },
+
+  addBattle() {
+    const result = document.getElementById('battle-result-input').value.trim();
+    if (!result) return this.toast('Enter a battle result.', 'error');
+    const notes = document.getElementById('battle-notes-input').value.trim();
+    RosterModel.addBattle(this.currentRoster, result, notes);
+    this.saveCurrentRoster();
+    document.getElementById('battle-result-input').value = '';
+    document.getElementById('battle-notes-input').value = '';
+    this.renderRosterEditor();
+    this.toast('Battle recorded.', 'success');
+  },
+
+  updateNotes() {
+    this.currentRoster.notes = document.getElementById('roster-notes').value;
+    this.saveCurrentRoster();
+  },
+
+  // === EXPORT / IMPORT ===
+  exportRoster(id) {
+    const json = Storage.exportRoster(id);
+    if (!json) return this.toast('Roster not found.', 'error');
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    const roster = Storage.getRoster(id);
+    a.download = `mordheim_${roster.name.replace(/\s+/g, '_').toLowerCase()}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+    this.toast('Roster exported.', 'success');
+  },
+
+  importRoster() {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.json';
+    input.onchange = (e) => {
+      const file = e.target.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = (ev) => {
+        try {
+          Storage.importRoster(ev.target.result);
+          this.renderRosterList();
+          this.toast('Roster imported!', 'success');
+        } catch (err) {
+          this.toast('Invalid roster file: ' + err.message, 'error');
+        }
+      };
+      reader.readAsText(file);
+    };
+    input.click();
+  },
+
+  // === DELETE ===
+  confirmDeleteRoster(id) {
+    const roster = Storage.getRoster(id);
+    if (!roster) return;
+    const overlay = document.getElementById('confirm-overlay');
+    document.getElementById('confirm-message').textContent = `Delete "${roster.name}"? This cannot be undone.`;
+    document.getElementById('confirm-yes').onclick = () => {
+      Storage.deleteRoster(id);
+      overlay.classList.remove('active');
+      this.renderRosterList();
+      this.toast(`"${roster.name}" deleted.`, 'info');
+    };
+    overlay.classList.add('active');
+  },
+
+  // === NAVIGATION ===
+  goBack() {
+    this.currentRoster = null;
+    this.showView('roster-list');
+    this.renderRosterList();
+  },
+
+  // === TABS ===
+  switchTab(tabId) {
+    document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+    document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+    document.querySelector(`[data-tab="${tabId}"]`).classList.add('active');
+    document.getElementById(`tab-${tabId}`).classList.add('active');
+  },
+
+  // === SECTION TOGGLE ===
+  toggleSection(sectionId) {
+    const header = document.querySelector(`#${sectionId} .section-header`);
+    const content = document.querySelector(`#${sectionId} .section-content`);
+    if (header && content) {
+      header.classList.toggle('collapsed');
+      content.classList.toggle('collapsed');
+    }
+  },
+
+  // === TOAST ===
+  toast(message, type = 'info') {
+    const container = document.getElementById('toast-container');
+    const toast = document.createElement('div');
+    toast.className = `toast ${type}`;
+    toast.textContent = message;
+    container.appendChild(toast);
+    setTimeout(() => {
+      toast.style.opacity = '0';
+      toast.style.transform = 'translateY(10px)';
+      toast.style.transition = 'all 0.3s ease';
+      setTimeout(() => toast.remove(), 300);
+    }, 3000);
+  },
+
+  // === CLOSE MODALS ===
+  closeModal(id) {
+    document.getElementById(id).classList.remove('active');
+  },
+
+  // === GLOBAL EVENTS ===
+  bindGlobalEvents() {
+    // Close modals on overlay click
+    document.querySelectorAll('.modal-overlay').forEach(overlay => {
+      overlay.addEventListener('click', (e) => {
+        if (e.target === overlay) overlay.classList.remove('active');
+      });
+    });
+
+    // Close confirm overlay
+    document.getElementById('confirm-no').addEventListener('click', () => {
+      document.getElementById('confirm-overlay').classList.remove('active');
+    });
+
+    // Roster name inline edit
+    document.getElementById('editor-roster-name').addEventListener('change', (e) => {
+      if (this.currentRoster) {
+        this.currentRoster.name = e.target.value.trim() || 'Unnamed Warband';
+        this.saveCurrentRoster();
+      }
+    });
+  },
+
+  // === UTILITY ===
+  esc(str) {
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+  }
+};


### PR DESCRIPTION
Browser-based warband roster manager for Mordheim campaigns. Supports all 8 core warbands with full warrior management (stats, equipment, skills, injuries, experience tracking), treasury management, battle logging, and roster export/import. Game data sourced from structured JSON files under data/ for easy amendments.

https://claude.ai/code/session_01NeYVAtPBxecfM17yRzbeZj