### PR TITLE
Fix broken warbands.json and hardcoded group size limit

### DIFF
--- a/data/warbands.json
+++ b/data/warbands.json
@@ -604,7 +604,6 @@
           "startingExp": 20,
           "skillAccess": ["combat", "academic", "strength"],
           "spellAccess": ["necromancy_restless_dead"]
-          "skillAccess": ["academic", "special"]
         },
         {
           "type": "necromancer",

--- a/js/ui.js
+++ b/js/ui.js
@@ -615,7 +615,10 @@ const UI = {
     if (!henchman) return;
     const newSize = (henchman.groupSize || 1) + delta;
     if (newSize < 1) return this.toast('Group must have at least 1 member.', 'error');
-    if (newSize > 5) return this.toast('Maximum group size is 5.', 'error');
+    const warband = DataService.getWarband(this.currentRoster.warbandId);
+    const template = warband.henchmen.find(h => h.type === henchman.type);
+    const maxSize = template?.maxGroupSize || 5;
+    if (newSize > maxSize) return this.toast(`Maximum group size is ${maxSize}.`, 'error');
     henchman.groupSize = newSize;
     this.saveCurrentRoster();
     this.renderRosterEditor();


### PR DESCRIPTION
Remove duplicate skillAccess key in Liche hero entry that made warbands.json invalid JSON, preventing the app from loading at all.

Fix adjustGroupSize to use per-template maxGroupSize instead of hardcoded 5, so henchman types with different limits (Marksmen 7, Sigmarite Sisters 10, Wight 3, Scarecrow 2) are enforced correctly.

https://claude.ai/code/session_01NeYVAtPBxecfM17yRzbeZj