### PR TITLE
Add styled tooltips to spell selection modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -378,7 +378,7 @@
   <script src="js/data.js?v=6"></script>
   <script src="js/storage.js?v=6"></script>
   <script src="js/roster.js?v=5"></script>
-  <script src="js/ui.js?v=10"></script>
+  <script src="js/ui.js?v=11"></script>
   <script>
     // Boot the app
     (async function() {

--- a/js/ui.js
+++ b/js/ui.js
@@ -857,7 +857,7 @@ const UI = {
         const alreadyHas = (warrior.spells || []).find(s => s.id === spell.id);
         const disabled = alreadyHas ? 'disabled' : '';
         const diff = spell.difficulty === 'Auto' ? 'Auto' : 'Difficulty: ' + spell.difficulty;
-        html += '<button class="btn btn-sm" ' + disabled + ' onclick="UI.selectSpell(\'' + listType + '\', ' + index + ', \'' + spell.id + '\')" title="' + this.esc(spell.description) + '">' + spell.name + ' (' + diff + ')</button>';
+        html += '<button class="btn btn-sm" ' + disabled + ' data-tooltip="' + this.escAttr(spell.description) + '" onclick="UI.selectSpell(\'' + listType + '\', ' + index + ', \'' + spell.id + '\')">' + spell.name + ' (' + diff + ')</button>';
       }
       html += '</div>';
     }


### PR DESCRIPTION
## Summary
- Switched spell buttons in the Add Spell modal from native browser `title` tooltips to the custom `data-tooltip` system
- Users can now read full spell descriptions on hover before adding a spell to a warrior
- Matches the existing equipment modal tooltip behavior

## Test plan
- [ ] Open any wizard's spell modal → hover over a spell → verify styled tooltip shows the full description
- [ ] Click a spell → verify it still adds correctly
- [ ] Verify tooltip doesn't overflow viewport edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)