### PR TITLE
Add Dwarf Troll Slayer hired sword

### DIFF
--- a/data/hired_swords.json
+++ b/data/hired_swords.json
@@ -131,6 +131,28 @@
       "warbandRestrictions": ["undead", "cult_of_the_possessed", "skaven", "restless_dead"]
     },
     {
+      "type": "dwarf_troll_slayer",
+      "name": "Dwarf Troll Slayer",
+      "max": 1,
+      "cost": 25,
+      "stats": { "M": 3, "WS": 4, "BS": 3, "S": 3, "T": 4, "W": 1, "I": 2, "A": 1, "Ld": 9 },
+      "specialRules": ["Deathwish", "Hard to Kill", "Hard Head"],
+      "startingExp": 0,
+      "skillAccess": ["combat", "strength", "troll_slayer_special"],
+      "spellAccess": [],
+      "equipmentAccess": ["hand_to_hand"],
+      "warbandAllowList": [
+        "reikland", "middenheim", "marienburg", "witch_hunters", "sisters_of_sigmar",
+        "averlander", "ostlander", "kislevites", "bretonnians", "tileans",
+        "hochland_bandits", "gunnery_school_of_nuln", "imperial_outriders",
+        "outlaws_of_stirwood", "pirates", "norse_explorers", "mootlanders",
+        "pit_fighters",
+        "dwarf_treasure_hunters", "dwarf_rangers",
+        "dark_elves", "shadow_warriors"
+      ],
+      "hiringNotes": "May be hired by Mercenaries and Witch Hunters. Warbands that include Elves may hire but must pay 20gc upkeep per battle instead of 10gc."
+    },
+    {
       "type": "bone_goliath",
       "name": "Bone Goliath",
       "max": 1,

--- a/index.html
+++ b/index.html
@@ -375,7 +375,7 @@
   <!-- ===== SCRIPTS ===== -->
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="js/cloud.js?v=9"></script>
-  <script src="js/data.js?v=6"></script>
+  <script src="js/data.js?v=7"></script>
   <script src="js/storage.js?v=6"></script>
   <script src="js/roster.js?v=5"></script>
   <script src="js/ui.js?v=11"></script>

--- a/js/data.js
+++ b/js/data.js
@@ -10,7 +10,7 @@ const DataService = {
   specialRules: null,
 
   async loadAll() {
-    const v = 'v=6';
+    const v = 'v=7';
     const [warbands, equipment, skills, injuries, advancement, spells, hiredSwords, specialRules] = await Promise.all([
       this.fetchJSON('data/warbands.json?' + v),
       this.fetchJSON('data/equipment.json?' + v),


### PR DESCRIPTION
## Summary
- Added Dwarf Troll Slayer as a new Hired Sword (25gc)
- Stats: M3 WS4 BS3 S3 T4 W1 I2 A1 Ld9
- Special rules: Deathwish, Hard to Kill, Hard Head (all pre-existing)
- Skill access: Combat, Strength, and Troll Slayer Special (Ferocious Charge, Monster Slayer, Berserker)
- Equipment: Hand-to-hand only (no armour — Slayers seek death!)
- Uses `warbandAllowList` to restrict hiring to Mercenary, Witch Hunter, Dwarf, and Elf warbands

## Test plan
- [x] Open a Reikland warband → verify "Dwarf Troll Slayer (25 gc)" appears in Hired Swords dropdown
- [x] Hire the Troll Slayer → verify stats and special rules display correctly
- [x] Open a Skaven warband → verify Troll Slayer does NOT appear
- [x] Check skill modal shows Combat, Strength, and Troll Slayer Special categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)