### PR TITLE
Add dark mode with theme toggle

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -4,7 +4,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Admin — Mordheim Roster</title>
-  <link rel="stylesheet" href="css/style.css?v=7">
+  <link rel="stylesheet" href="css/style.css?v=11">
+  <script>
+    // Apply theme before paint to prevent flash
+    (function() {
+      const stored = localStorage.getItem('mordheim_theme');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      if (stored === 'dark' || (!stored && prefersDark)) {
+        document.documentElement.dataset.theme = 'dark';
+      }
+    })();
+  </script>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9760;</text></svg>">
   <style>
     .admin-container { max-width: 900px; margin: 2rem auto; padding: 0 1rem; }
@@ -14,23 +24,23 @@
     .admin-signin { max-width: 360px; margin: 4rem auto; }
     .admin-signin h2 { color: var(--accent); margin-bottom: 1rem; }
     .admin-signin input { width: 100%; padding: 0.6rem; margin-bottom: 0.8rem; background: var(--bg-card); border: 1px solid var(--border); color: var(--text); border-radius: 4px; font-size: 0.95rem; box-sizing: border-box; }
-    .admin-signin .error { color: #e74c3c; font-size: 0.85rem; margin-bottom: 0.6rem; }
+    .admin-signin .error { color: var(--danger); font-size: 0.85rem; margin-bottom: 0.6rem; }
     .admin-info { display: flex; align-items: center; gap: 0.8rem; font-size: 0.9rem; color: var(--text-muted); }
     .user-table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
     .user-table th { text-align: left; padding: 0.6rem 0.8rem; border-bottom: 2px solid var(--border); color: var(--accent); font-weight: 600; }
     .user-table td { padding: 0.6rem 0.8rem; border-bottom: 1px solid var(--border); }
-    .user-table tr:hover td { background: rgba(255,255,255,0.03); }
+    .user-table tr:hover td { background: var(--bg-card-hover); }
     .user-table select { background: var(--bg-card); border: 1px solid var(--border); color: var(--text); padding: 0.3rem 0.5rem; border-radius: 4px; font-size: 0.85rem; }
     .user-table .btn-save { padding: 0.25rem 0.6rem; font-size: 0.8rem; }
     .user-table .admin-badge { background: var(--accent); color: var(--bg); padding: 0.15rem 0.5rem; border-radius: 3px; font-size: 0.75rem; font-weight: 600; }
     .user-count { color: var(--text-muted); font-size: 0.85rem; }
     .toast-admin { position: fixed; bottom: 1.5rem; right: 1.5rem; padding: 0.7rem 1.2rem; border-radius: 6px; font-size: 0.9rem; z-index: 9999; animation: fadeIn 0.2s; }
-    .toast-admin.success { background: #27ae60; color: #fff; }
-    .toast-admin.error { background: #e74c3c; color: #fff; }
+    .toast-admin.success { background: var(--success); color: #fff; }
+    .toast-admin.error { background: var(--danger); color: #fff; }
     @keyframes fadeIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
     .loading { color: var(--text-muted); text-align: center; padding: 2rem; }
     .unauthorized { text-align: center; padding: 3rem; color: var(--text-muted); }
-    .unauthorized h2 { color: #e74c3c; }
+    .unauthorized h2 { color: var(--danger); }
   </style>
 </head>
 <body>

--- a/css/style.css
+++ b/css/style.css
@@ -28,6 +28,31 @@
   --font-display: 'Cinzel', serif;
 }
 
+/* ===== DARK MODE THEME ===== */
+[data-theme="dark"] {
+  --bg-darkest: #1a1816;
+  --bg-dark: #242220;
+  --bg-card: #2e2b28;
+  --bg-card-hover: #36332f;
+  --bg-input: #242220;
+  --border: #3d3a36;
+  --border-hover: #5a5550;
+  --accent: #c9a033;
+  --accent-hover: #d4ab3d;
+  --accent-dim: #b89428;
+  --accent-glow: rgba(201, 160, 51, 0.15);
+  --danger: #d04444;
+  --danger-hover: #e05555;
+  --success: #3da63d;
+  --success-hover: #4ab84a;
+  --text: #e0dbd3;
+  --text-dim: #a39a8e;
+  --text-muted: #8a8078;
+  --text-bright: #f0ebe5;
+  --skull: #c9a033;
+  --shadow: rgba(0, 0, 0, 0.3);
+}
+
 *, *::before, *::after {
   box-sizing: border-box;
   margin: 0;
@@ -1673,3 +1698,70 @@ select.form-control {
   .tier-link { font-size: 0.7rem; }
   .tier-table th, .tier-table td { padding: 0.4rem 0.5rem; font-size: 0.78rem; }
 }
+
+/* ===== DARK MODE OVERRIDES ===== */
+
+/* Smooth theme transition */
+body, .app-header, .modal, .warrior-card, .roster-card,
+.tag, .btn, input, select, textarea, .section-header,
+.modal-overlay, .tooltip-popup {
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+/* Notification banner keeps its own hardcoded parchment style in all themes */
+[data-theme="dark"] .notification-banner {
+  background: linear-gradient(135deg, #fef3e0 0%, #fdecc8 100%);
+  border-bottom-color: #e8d5a0;
+  color: #2a231a;
+}
+
+[data-theme="dark"] .notification-banner-dismiss {
+  color: #6b6052;
+}
+
+/* Noise background — slightly brighter in dark mode */
+[data-theme="dark"] body {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)' opacity='0.06'/%3E%3C/svg%3E");
+}
+
+/* Modal overlay — darker backdrop */
+[data-theme="dark"] .modal-overlay {
+  background: rgba(0, 0, 0, 0.65);
+}
+
+/* Tag colors — skill and spell need explicit dark overrides for contrast */
+[data-theme="dark"] .tag.skill {
+  border-color: #5a9ad4;
+  color: #7ab8e8;
+}
+
+[data-theme="dark"] .tag.spell-tag {
+  border-color: #a86cc4;
+  color: #c490de;
+}
+
+[data-theme="dark"] .tag.injury {
+  color: #e06060;
+}
+
+/* Theme toggle button */
+.btn-theme-toggle {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  border-radius: var(--radius);
+  padding: 0.3rem 0.5rem;
+  font-size: 1rem;
+  cursor: pointer;
+  line-height: 1;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.btn-theme-toggle:hover {
+  border-color: var(--border-hover);
+  color: var(--accent);
+}
+
+/* Admin status badges */
+.status-active { color: var(--success); }
+.status-inactive { color: var(--text-muted); }

--- a/index.html
+++ b/index.html
@@ -7,7 +7,17 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/style.css?v=10">
+  <link rel="stylesheet" href="css/style.css?v=11">
+  <script>
+    // Apply theme before paint to prevent flash
+    (function() {
+      const stored = localStorage.getItem('mordheim_theme');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      if (stored === 'dark' || (!stored && prefersDark)) {
+        document.documentElement.dataset.theme = 'dark';
+      }
+    })();
+  </script>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9760;</text></svg>">
 </head>
 <body>
@@ -27,6 +37,7 @@
     <div class="header-right">
       <div id="auth-area" class="auth-area"></div>
       <div class="header-actions">
+        <button id="btn-theme-toggle" class="btn-theme-toggle" title="Toggle dark mode" aria-label="Toggle dark mode">&#9790;</button>
         <button class="btn btn-sm btn-primary" onclick="UI.openCreateModal()"><span class="btn-label-full">+ New Warband</span><span class="btn-label-compact">+</span></button>
       </div>
     </div>

--- a/js/admin.js
+++ b/js/admin.js
@@ -209,8 +209,8 @@ const Admin = {
     const rows = notifications.map(n => {
       const date = new Date(n.created_at).toLocaleDateString();
       const status = n.is_active
-        ? '<span style="color:#27ae60;">Active</span>'
-        : '<span style="color:#999;">Inactive</span>';
+        ? '<span class="status-active">Active</span>'
+        : '<span class="status-inactive">Inactive</span>';
       return `
         <tr>
           <td style="max-width:400px; word-break:break-word;">${this.esc(n.message)}</td>

--- a/js/ui.js
+++ b/js/ui.js
@@ -3,10 +3,42 @@ const UI = {
   currentRoster: null,
 
   init() {
+    this.initTheme();
     this.bindGlobalEvents();
     this.renderAuthState();
     this.showView('roster-list');
     this.renderRosterList();
+  },
+
+  // === THEME ===
+  initTheme() {
+    // Sync toggle icon with current theme (theme already applied by inline script)
+    this.updateThemeIcon();
+
+    // Listen for system theme changes (only when user hasn't set a preference)
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+      if (!localStorage.getItem('mordheim_theme')) {
+        document.documentElement.dataset.theme = e.matches ? 'dark' : 'light';
+        this.updateThemeIcon();
+      }
+    });
+  },
+
+  toggleTheme() {
+    const isDark = document.documentElement.dataset.theme === 'dark';
+    const next = isDark ? 'light' : 'dark';
+    document.documentElement.dataset.theme = next;
+    localStorage.setItem('mordheim_theme', next);
+    this.updateThemeIcon();
+  },
+
+  updateThemeIcon() {
+    const btn = document.getElementById('btn-theme-toggle');
+    if (!btn) return;
+    const isDark = document.documentElement.dataset.theme === 'dark';
+    btn.textContent = isDark ? '\u2600' : '\u263E'; // ☀ / ☾
+    btn.title = isDark ? 'Switch to light mode' : 'Switch to dark mode';
+    btn.setAttribute('aria-label', btn.title);
   },
 
   // === AUTH UI ===
@@ -1480,6 +1512,9 @@ const UI = {
 
   // === GLOBAL EVENTS ===
   bindGlobalEvents() {
+    // Theme toggle
+    document.getElementById('btn-theme-toggle').addEventListener('click', () => this.toggleTheme());
+
     // Close modals on overlay click
     document.querySelectorAll('.modal-overlay').forEach(overlay => {
       overlay.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary

- Adds a dark/light theme toggle (☀/☾) to the app header with `localStorage` persistence and system preference (`prefers-color-scheme`) as the default on first visit
- Defines a `[data-theme="dark"]` CSS palette — warm dark browns with desaturated gold accent, per Apple HIG guidelines
- Overrides tag colors (skill, spell, injury), modal overlay backdrop, and SVG noise texture for dark mode
- Adds flash-prevention inline scripts to both `index.html` and `admin.html` so the correct theme is applied before first paint
- Admin page inherits theme automatically from `localStorage` (no toggle button needed)
- Fixes all hardcoded hex colors in `admin.html` and `admin.js` replaced with CSS variables
- Pins notification banner to its parchment styling in dark mode to preserve readability

Closes #20

## Test plan

- [ ] Toggle switches between dark and light mode with smooth transition
- [ ] Theme persists across page reload (no flash of wrong theme)
- [ ] System dark/light preference is respected on first visit
- [ ] Notification banner remains readable in both modes
- [ ] Modal overlay is visible and sufficiently dark in dark mode
- [ ] Tag colours (skill, spell, injury) are legible on dark surfaces
- [ ] Admin page inherits correct theme without its own toggle
- [ ] PDF export unaffected (always light)

🤖 Generated with [Claude Code](https://claude.com/claude-code)