### PR TITLE
Add feedback link footer

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1765,3 +1765,22 @@ body, .app-header, .modal, .warrior-card, .roster-card,
 /* Admin status badges */
 .status-active { color: var(--success); }
 .status-inactive { color: var(--text-muted); }
+
+/* ===== FOOTER ===== */
+.app-footer {
+  text-align: center;
+  padding: 1.5rem 2rem;
+  margin-top: 2rem;
+  border-top: 1px solid var(--border);
+}
+
+.feedback-link {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+.feedback-link:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/style.css?v=11">
+  <link rel="stylesheet" href="css/style.css?v=12">
   <script>
     // Apply theme before paint to prevent flash
     (function() {
@@ -216,6 +216,14 @@
 
       </div>
     </div>
+
+    <!-- ===== FOOTER ===== -->
+    <footer class="app-footer">
+      <a href="https://github.com/YellowSkin22/MeatHammerMordHeim/issues"
+         target="_blank" rel="noopener noreferrer" class="feedback-link">
+        Report a bug or suggest a feature ↗
+      </a>
+    </footer>
 
   </div>
 


### PR DESCRIPTION
## Summary

- Adds a footer to the app with a "Report a bug or suggest a feature ↗" link pointing to the GitHub Issues page
- Footer uses CSS variables so it inherits both light and dark themes automatically
- Link opens in a new tab with `rel="noopener noreferrer"`

## Test plan

- [ ] Footer visible on roster list view
- [ ] Link opens GitHub Issues in a new tab
- [ ] Correct styling in light mode
- [ ] Correct styling in dark mode
- [ ] Readable on mobile viewport (375px)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)