### PR TITLE
Fix RLS error when deactivating notifications

### DIFF
--- a/supabase/migrations/20260316000001_fix_notifications_admin_select.sql
+++ b/supabase/migrations/20260316000001_fix_notifications_admin_select.sql
@@ -1,0 +1,6 @@
+-- Required: PostgreSQL applies SELECT USING as implicit WITH CHECK on UPDATE new rows.
+-- OR-logic across permissive policies lets admins bypass the is_active = true constraint,
+-- allowing admins to deactivate notifications (set is_active = false) without RLS errors.
+CREATE POLICY "Admins can read all notifications"
+  ON public.notifications FOR SELECT
+  USING (public.is_admin(auth.uid()));


### PR DESCRIPTION
## Summary

- Adds an admin SELECT policy on `public.notifications` so admins can set `is_active = false` without hitting a row-level security error
- Root cause: PostgreSQL applies a SELECT policy's `USING` clause as an implicit `WITH CHECK` on UPDATE new rows; the public policy (`is_active = true`) was rejecting the new row when deactivating
- Fix uses OR-logic across permissive policies — the new admin policy passes even when the public policy rejects the new row

Closes #36

## Test plan

- [ ] Sign into admin panel and toggle an active notification to Inactive — no error shown
- [ ] Toggle it back to Active — no error shown
- [ ] Confirm public users still only see active notifications (existing SELECT policy untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)