### PR TITLE
Add Lad's Got Talent henchman-to-hero promotion

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,6 +351,26 @@
     </div>
   </div>
 
+  <!-- ===== LAD'S GOT TALENT MODAL ===== -->
+  <div id="lads-got-talent-modal" class="modal-overlay">
+    <div class="modal">
+      <div class="modal-header">
+        <h3>Lad's Got Talent!</h3>
+        <button class="btn btn-icon" onclick="UI.closeModal('lads-got-talent-modal')">&#10005;</button>
+      </div>
+      <div class="modal-body">
+        <p><strong id="lgt-henchman-name"></strong> has shown exceptional talent and will be promoted to Hero. They keep all their stats, equipment, and experience.</p>
+        <p style="margin-top:0.75rem; font-weight:600;">Choose 2 skill lists for this hero:</p>
+        <div id="lgt-skill-lists" style="margin-top:0.5rem;"></div>
+        <p class="text-dim" style="margin-top:0.75rem; font-size:0.85rem;">After promotion, make one roll on the Heroes Advance table and apply the result manually.</p>
+      </div>
+      <div class="modal-footer">
+        <button class="btn" onclick="UI.closeModal('lads-got-talent-modal')">Cancel</button>
+        <button class="btn btn-primary" onclick="UI.submitLadsGotTalent()">Promote to Hero</button>
+      </div>
+    </div>
+  </div>
+
   <!-- ===== AUTH MODAL ===== -->
   <div id="auth-modal" class="modal-overlay">
     <div class="modal">
@@ -396,8 +416,8 @@
   <script src="js/cloud.js?v=9"></script>
   <script src="js/data.js?v=7"></script>
   <script src="js/storage.js?v=6"></script>
-  <script src="js/roster.js?v=5"></script>
-  <script src="js/ui.js?v=12"></script>
+  <script src="js/roster.js?v=6"></script>
+  <script src="js/ui.js?v=13"></script>
   <script>
     // Boot the app
     (async function() {

--- a/js/roster.js
+++ b/js/roster.js
@@ -100,6 +100,30 @@ const RosterModel = {
     };
   },
 
+  promoteHenchmanToHero(henchman, skillAccess) {
+    return {
+      id: Storage.generateId(),
+      type: henchman.type,
+      typeName: henchman.typeName,
+      name: henchman.name,
+      isHero: true,
+      isPromotedHenchman: true,
+      stats: { ...henchman.stats },
+      baseStats: { ...henchman.stats },
+      equipment: JSON.parse(JSON.stringify(henchman.equipment)),
+      skills: [],
+      spells: [],
+      injuries: JSON.parse(JSON.stringify(henchman.injuries)),
+      experience: henchman.experience,
+      advancementCount: 0,
+      missNextGame: false,
+      cost: henchman.cost,
+      specialRules: [...henchman.specialRules],
+      skillAccess: skillAccess,
+      notes: henchman.notes || '',
+    };
+  },
+
   addEquipment(warrior, itemId) {
     const item = DataService.getEquipmentItem(itemId);
     if (!item) return false;

--- a/js/ui.js
+++ b/js/ui.js
@@ -542,6 +542,7 @@ const UI = {
             ${!isHero ? `
               <button class="btn btn-sm" onclick="UI.adjustGroupSize(${index}, 1)">+1 Member</button>
               <button class="btn btn-sm" onclick="UI.adjustGroupSize(${index}, -1)">-1 Member</button>
+              <button class="btn btn-sm" onclick="UI.openLadsGotTalentModal(${index})">Lad's Got Talent</button>
             ` : ''}
             <button class="btn btn-sm btn-danger" onclick="UI.removeWarrior('${listType}', ${index})">Remove</button>
           </div>
@@ -691,6 +692,69 @@ const UI = {
     this.toast(`${name} created!`, 'success');
   },
 
+  // === LAD'S GOT TALENT ===
+  openLadsGotTalentModal(henchmanIndex) {
+    const r = this.currentRoster;
+    const warband = DataService.getWarband(r.warbandId);
+
+    // Max heroes check
+    const maxHeroes = warband.heroes.reduce((sum, h) => sum + (h.max || 0), 0);
+    if (r.heroes.length >= maxHeroes) {
+      return this.toast('Already at max heroes (' + maxHeroes + '). Roll again on the advancement table.', 'error');
+    }
+
+    // Collect all skill lists available to heroes in this warband (deduplicated)
+    const allSkillLists = [...new Set(warband.heroes.flatMap(h => h.skillAccess || []))];
+
+    const modal = document.getElementById('lads-got-talent-modal');
+    modal.dataset.henchmanIndex = henchmanIndex;
+
+    const henchman = r.henchmen[henchmanIndex];
+    document.getElementById('lgt-henchman-name').textContent = henchman.typeName;
+
+    // Render skill list checkboxes
+    const listContainer = document.getElementById('lgt-skill-lists');
+    listContainer.innerHTML = allSkillLists.map(catId => {
+      const catName = DataService.skills[catId]?.name || catId;
+      return '<label style="display:block; margin-bottom:0.4rem;">' +
+        '<input type="checkbox" class="lgt-skill-checkbox" value="' + catId + '"> ' +
+        this.esc(catName) +
+      '</label>';
+    }).join('');
+
+    modal.classList.add('active');
+  },
+
+  submitLadsGotTalent() {
+    const modal = document.getElementById('lads-got-talent-modal');
+    const henchmanIndex = parseInt(modal.dataset.henchmanIndex);
+    const r = this.currentRoster;
+    const henchman = r.henchmen[henchmanIndex];
+    if (!henchman) return;
+
+    // Validate exactly 2 skill lists chosen
+    const checked = [...document.querySelectorAll('.lgt-skill-checkbox:checked')];
+    if (checked.length !== 2) {
+      return this.toast('Choose exactly 2 skill lists.', 'error');
+    }
+    const skillAccess = checked.map(cb => cb.value);
+
+    // Create promoted hero
+    const hero = RosterModel.promoteHenchmanToHero(henchman, skillAccess);
+    r.heroes.push(hero);
+
+    // Reduce henchman group size; remove group if now empty
+    henchman.groupSize = (henchman.groupSize || 1) - 1;
+    if (henchman.groupSize <= 0) {
+      r.henchmen.splice(henchmanIndex, 1);
+    }
+
+    this.saveCurrentRoster();
+    this.renderRosterEditor();
+    modal.classList.remove('active');
+    this.toast(hero.name + ' promoted to Hero! Make one roll on the Heroes Advance table.', 'success');
+  },
+
   removeWarrior(listType, index) {
     const r = this.currentRoster;
     const warrior = r[listType][index];
@@ -806,7 +870,9 @@ const UI = {
   openSkillModal(listType, index) {
     const warrior = this.currentRoster[listType][index];
     let accessCategories;
-    if (listType === 'customWarriors') {
+    if (warrior.isPromotedHenchman) {
+      accessCategories = warrior.skillAccess || [];
+    } else if (listType === 'customWarriors') {
       accessCategories = Object.keys(DataService.skills);
     } else if (listType === 'hiredSwords') {
       const template = DataService.getHiredSwordTemplate(warrior.type);
@@ -860,7 +926,9 @@ const UI = {
   openSpellModal(listType, index) {
     const warrior = this.currentRoster[listType][index];
     let spellLists;
-    if (listType === 'customWarriors') {
+    if (warrior.isPromotedHenchman) {
+      spellLists = [];
+    } else if (listType === 'customWarriors') {
       spellLists = Object.keys(DataService.spells);
     } else if (listType === 'hiredSwords') {
       const template = DataService.getHiredSwordTemplate(warrior.type);


### PR DESCRIPTION
## Summary

- Adds the Mordheim "Lad's Got Talent" rule: promotes a henchman to Hero when rolling 12 on the advancement table
- Dedicated modal lets users pick exactly 2 skill lists from those available to warband heroes
- Promoted hero keeps all stats, equipment, experience, injuries, and notes — no re-entry needed
- Max heroes validation blocks promotion when the warband is full
- Skill/spell modals correctly route promoted henchmen via `isPromotedHenchman` flag

Closes #34

## Test plan

- [ ] "Lad's Got Talent" button appears on all henchman cards
- [ ] Button blocked with error toast when at max heroes
- [ ] Modal shows correct henchman name and all hero skill categories
- [ ] Exactly 2 skill lists must be selected (validation toast otherwise)
- [ ] Henchman group size decreases by 1 (removed if empty)
- [ ] Promoted hero appears in Heroes section with correct stats, equipment, XP
- [ ] No false "modified" stat highlights on promoted hero
- [ ] Skill modal shows only the 2 chosen categories
- [ ] Warband rating recalculates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)