### PR TITLE
Fix hero cap not counting promoted henchmen

### DIFF
--- a/index.html
+++ b/index.html
@@ -417,7 +417,7 @@
   <script src="js/data.js?v=7"></script>
   <script src="js/storage.js?v=6"></script>
   <script src="js/roster.js?v=6"></script>
-  <script src="js/ui.js?v=13"></script>
+  <script src="js/ui.js?v=14"></script>
   <script>
     // Boot the app
     (async function() {

--- a/js/ui.js
+++ b/js/ui.js
@@ -348,12 +348,14 @@ const UI = {
 
     // Hero add dropdown
     const heroAddContainer = document.getElementById('hero-add-buttons');
+    const maxHeroes = warband.heroes.reduce((sum, h) => sum + (h.max || 0), 0);
+    const atTotalCap = r.heroes.length >= maxHeroes;
     heroAddContainer.innerHTML = `
       <select id="hero-add-select" class="form-control" style="font-size:0.8rem; padding:0.2rem 2rem 0.2rem 0.4rem;" onclick="event.stopPropagation()" onchange="UI.addWarriorFromSelect('heroes')">
         <option value="">+ Add Hero</option>
         ${warband.heroes.map(ht => {
           const currentCount = r.heroes.filter(h => h.type === ht.type).length;
-          const atMax = currentCount >= ht.max;
+          const atMax = atTotalCap || currentCount >= ht.max;
           return `<option value="${ht.type}" ${atMax ? 'disabled' : ''}>${ht.name} (${ht.cost} gc)${atMax ? ' \u2713' : ''}</option>`;
         }).join('')}
       </select>
@@ -589,6 +591,11 @@ const UI = {
       const currentCount = r.heroes.filter(h => h.type === type).length;
       if (currentCount >= template.max) {
         return this.toast(`Maximum ${template.name}s reached (${template.max}).`, 'error');
+      }
+      // Total hero cap (includes promoted henchmen)
+      const maxHeroes = warband.heroes.reduce((sum, h) => sum + (h.max || 0), 0);
+      if (r.heroes.length >= maxHeroes) {
+        return this.toast(`Already at max heroes (${maxHeroes}).`, 'error');
       }
     }
 


### PR DESCRIPTION
## Summary
- Fixes #43
- `addWarrior()` only checked per-type hero counts, so promoted henchmen (which have a henchman type) were invisible to the total hero cap — allowing a 6th hero after a Lad's Got Talent promotion
- Added a total hero cap guard in `addWarrior()` and updated the hero add dropdown in `renderWarriorsTab()` to disable all options when the cap is reached (including promoted henchmen)

## Test plan
- [ ] Create a warband and fill all hero slots (e.g. 5 for Reikland)
- [ ] Remove one hero, promote a henchman via Lad's Got Talent
- [ ] Verify all hero dropdown options are disabled (showing ✓)
- [ ] Verify attempting to add a hero via JS (`UI.addWarrior`) shows "Already at max heroes" toast
- [ ] Verify per-type max still works (e.g. can't add a 2nd Captain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)