### PR TITLE
chore: add github-issues slash command and Claude settings

### DIFF
--- a/.claude/commands/github-issues.md
+++ b/.claude/commands/github-issues.md
@@ -1,0 +1,5 @@
+Run `gh issue list --limit 100` to fetch all open issues for this project, then display them as a clean markdown table with columns: **#**, **Title**, **Labels**, and **Opened**.
+
+Format the Opened date as `YYYY-MM-DD`. If an issue has no labels, leave the cell blank. Sort by issue number descending (newest first, which is the default).
+
+After the table, print a one-line summary: `X open issues`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "enableAllProjectMcpServers": true
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/commands/github-issues.md` — a slash command that lists open GitHub issues as a markdown table
- Adds `.claude/settings.json` — Claude Code configuration

## Test plan
- [ ] `/github-issues` slash command works in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)