### PR TITLE
fix: prevent skill-check loop in /github-issues slash command

### DIFF
--- a/.claude/commands/github-issues.md
+++ b/.claude/commands/github-issues.md
@@ -1,3 +1,7 @@
+<SUBAGENT-STOP>
+Do not invoke the Skill tool. Execute this command directly using the Bash tool.
+</SUBAGENT-STOP>
+
 Run `gh issue list --limit 100` to fetch all open issues for this project, then display them as a clean markdown table with columns: **#**, **Title**, **Labels**, and **Opened**.
 
 Format the Opened date as `YYYY-MM-DD`. If an issue has no labels, leave the cell blank. Sort by issue number descending (newest first, which is the default).


### PR DESCRIPTION
## Summary
- Adds `<SUBAGENT-STOP>` directive to `.claude/commands/github-issues.md` so the `using-superpowers` rule skips the skill-check when this slash command runs

## Root cause
When `/github-issues` fires, the superpowers rule treats the injected prompt as a new task and calls `Skill("github-issues")` → "Unknown skill" error. `<SUBAGENT-STOP>` signals that this is a direct execution context, not a new task requiring skill discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)