### PR TITLE
feat: migrate hired swords to Uncle-Mel sync (72 entries)

### DIFF
--- a/.claude/commands/github-issues.md
+++ b/.claude/commands/github-issues.md
@@ -1,9 +1,0 @@
-<SUBAGENT-STOP>
-Do not invoke the Skill tool. Execute this command directly using the Bash tool.
-</SUBAGENT-STOP>
-
-Run `gh issue list --limit 100` to fetch all open issues for this project, then display them as a clean markdown table with columns: **#**, **Title**, **Labels**, and **Opened**.
-
-Format the Opened date as `YYYY-MM-DD`. If an issue has no labels, leave the cell blank. Sort by issue number descending (newest first, which is the default).
-
-After the table, print a one-line summary: `X open issues`.

--- a/data/.sync-state.json
+++ b/data/.sync-state.json
@@ -1,25 +1,25 @@
 {
-  "lastChecked": "2026-04-01T08:19:13.673Z",
+  "lastChecked": "2026-04-01T08:36:01.351Z",
   "files": {
     "data/mergedEquipment.json": {
       "sha": "aca5cc003a135eb5ef03a41f798c0fd9a1ada24b",
-      "syncedAt": "2026-03-30T07:40:06.582Z"
+      "syncedAt": "2026-04-01T08:36:01.351Z"
     },
     "data/skills.json": {
       "sha": "aca5cc003a135eb5ef03a41f798c0fd9a1ada24b",
-      "syncedAt": "2026-03-30T07:40:06.582Z"
+      "syncedAt": "2026-04-01T08:36:01.351Z"
     },
     "data/magic.json": {
       "sha": "aca5cc003a135eb5ef03a41f798c0fd9a1ada24b",
-      "syncedAt": "2026-03-30T07:40:06.582Z"
+      "syncedAt": "2026-04-01T08:36:01.351Z"
     },
     "data/warbandFiles": {
       "sha": "6f9aa8d8335b09fa27950a002ea0044d06ac0361",
-      "syncedAt": "2026-03-30T07:40:06.582Z"
+      "syncedAt": "2026-04-01T08:36:01.351Z"
     },
     "data/hiredSwords.json": {
       "sha": "5d382bdf33abdad008028f157ec47fed12027f8e",
-      "syncedAt": "2026-04-01T08:19:13.673Z"
+      "syncedAt": "2026-04-01T08:36:01.351Z"
     }
   }
 }

--- a/data/.sync-state.json
+++ b/data/.sync-state.json
@@ -1,5 +1,5 @@
 {
-  "lastChecked": "2026-03-30T07:40:06.582Z",
+  "lastChecked": "2026-04-01T08:19:13.673Z",
   "files": {
     "data/mergedEquipment.json": {
       "sha": "aca5cc003a135eb5ef03a41f798c0fd9a1ada24b",
@@ -16,6 +16,10 @@
     "data/warbandFiles": {
       "sha": "6f9aa8d8335b09fa27950a002ea0044d06ac0361",
       "syncedAt": "2026-03-30T07:40:06.582Z"
+    },
+    "data/hiredSwords.json": {
+      "sha": "5d382bdf33abdad008028f157ec47fed12027f8e",
+      "syncedAt": "2026-04-01T08:19:13.673Z"
     }
   }
 }

--- a/data/hired_swords.json
+++ b/data/hired_swords.json
@@ -1,170 +1,4073 @@
 {
   "hiredSwords": [
     {
-      "type": "ogre_bodyguard",
-      "name": "Ogre Bodyguard",
+      "type": "dwarf_troll_slayer",
+      "name": "Dwarf Troll Slayer",
       "max": 1,
-      "cost": 80,
-      "stats": { "M": 6, "WS": 3, "BS": 2, "S": 4, "T": 4, "W": 3, "I": 3, "A": 2, "Ld": 7 },
-      "specialRules": ["Fear", "Large Target"],
+      "cost": 25,
+      "stats": {
+        "M": 3,
+        "WS": 4,
+        "BS": 3,
+        "S": 3,
+        "T": 4,
+        "W": 1,
+        "I": 2,
+        "A": 1,
+        "Ld": 9
+      },
+      "specialRules": [
+        "Deathwish",
+        "Hard to Kill",
+        "Hard Head"
+      ],
       "startingExp": 0,
-      "skillAccess": ["combat", "strength"],
+      "skillAccess": [
+        "combat",
+        "strength"
+      ],
       "spellAccess": [],
-      "equipmentAccess": ["hand_to_hand", "armour"],
-      "warbandRestrictions": []
-    },
-    {
-      "type": "halfling_scout",
-      "name": "Halfling Scout",
-      "max": 1,
-      "cost": 15,
-      "stats": { "M": 4, "WS": 2, "BS": 4, "S": 2, "T": 2, "W": 1, "I": 4, "A": 1, "Ld": 8 },
-      "specialRules": ["Sneaky"],
-      "startingExp": 0,
-      "skillAccess": ["shooting", "speed"],
-      "spellAccess": [],
-      "equipmentAccess": ["hand_to_hand", "missiles"],
-      "warbandRestrictions": []
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "witch-hunters",
+        "hochland-bandits",
+        "ostlander-mercenaries",
+        "pirates",
+        "lustrian-reavers",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
     },
     {
       "type": "elf_ranger",
       "name": "Elf Ranger",
       "max": 1,
-      "cost": 80,
-      "stats": { "M": 5, "WS": 4, "BS": 4, "S": 3, "T": 3, "W": 1, "I": 6, "A": 1, "Ld": 8 },
-      "specialRules": ["Excellent Sight"],
+      "cost": 40,
+      "stats": {
+        "M": 5,
+        "WS": 4,
+        "BS": 5,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 6,
+        "A": 1,
+        "Ld": 8
+      },
+      "specialRules": [
+        "Seeker",
+        "Excellent Sight"
+      ],
       "startingExp": 0,
-      "skillAccess": ["combat", "shooting", "speed"],
+      "skillAccess": [
+        "shooting",
+        "speed"
+      ],
       "spellAccess": [],
-      "equipmentAccess": ["hand_to_hand", "missiles", "armour"],
-      "warbandRestrictions": ["undead", "cult_of_the_possessed", "skaven"]
-    },
-    {
-      "type": "warlock",
-      "name": "Warlock",
-      "max": 1,
-      "cost": 35,
-      "stats": { "M": 4, "WS": 3, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
-      "specialRules": ["Wizard"],
-      "startingExp": 0,
-      "skillAccess": ["academic", "speed"],
-      "spellAccess": ["lesser_magic"],
-      "equipmentAccess": ["hand_to_hand"],
-      "warbandRestrictions": ["witch_hunters", "sisters_of_sigmar"]
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "witch-hunters",
+        "hochland-bandits",
+        "ostlander-mercenaries",
+        "pirates",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
     },
     {
       "type": "freelancer",
       "name": "Freelancer",
       "max": 1,
       "cost": 50,
-      "stats": { "M": 4, "WS": 4, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 3,
+        "A": 1,
+        "Ld": 7
+      },
       "specialRules": [],
       "startingExp": 0,
-      "skillAccess": ["combat", "shooting", "strength", "speed"],
+      "skillAccess": [
+        "combat",
+        "strength"
+      ],
       "spellAccess": [],
-      "equipmentAccess": ["hand_to_hand", "missiles", "armour"],
-      "warbandRestrictions": []
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "witch-hunters",
+        "hochland-bandits",
+        "imperial-outriders",
+        "ostlander-mercenaries",
+        "pirates",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "halfling_scout",
+      "name": "Halfling Scout",
+      "max": 1,
+      "cost": 15,
+      "stats": {
+        "M": 4,
+        "WS": 2,
+        "BS": 4,
+        "S": 2,
+        "T": 2,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 8
+      },
+      "specialRules": [
+        "Cook"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "shooting",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "forest-goblins",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "maneaters",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "ogre_bodyguard",
+      "name": "Ogre Bodyguard",
+      "max": 1,
+      "cost": 80,
+      "stats": {
+        "M": 6,
+        "WS": 3,
+        "BS": 2,
+        "S": 4,
+        "T": 4,
+        "W": 3,
+        "I": 3,
+        "A": 2,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Fear",
+        "Large Target"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "strength"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "cult-of-the-possessed",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "orc-mob",
+        "ostlander-mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "undead",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "black-orcs",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "forest-goblins",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "tomb-guardians",
+        "black-dwarfs",
+        "bretonnian-chapel-guard",
+        "lustrian-reavers",
+        "maneaters",
+        "the_kurgan",
+        "merchant-caravans",
+        "night-goblins",
+        "norse-explorers",
+        "the-restless-dead",
+        "the-sons-of-hashut"
+      ]
     },
     {
       "type": "pit_fighter",
       "name": "Pit Fighter",
       "max": 1,
       "cost": 30,
-      "stats": { "M": 4, "WS": 4, "BS": 3, "S": 3, "T": 4, "W": 1, "I": 3, "A": 1, "Ld": 7 },
-      "specialRules": ["Pit Fighter"],
+      "stats": {
+        "M": 4,
+        "WS": 4,
+        "BS": 3,
+        "S": 4,
+        "T": 4,
+        "W": 1,
+        "I": 4,
+        "A": 2,
+        "Ld": 7
+      },
+      "specialRules": [],
       "startingExp": 0,
-      "skillAccess": ["combat", "strength"],
+      "skillAccess": [
+        "combat",
+        "strength",
+        "speed"
+      ],
       "spellAccess": [],
-      "equipmentAccess": ["hand_to_hand", "armour"],
-      "warbandRestrictions": []
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "cult-of-the-possessed",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "orc-mob",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "black-orcs",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "forest-goblins",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "black-dwarfs",
+        "bretonnian-chapel-guard",
+        "the_kurgan",
+        "merchant-caravans",
+        "night-goblins",
+        "norse-explorers",
+        "the-sons-of-hashut",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "warlock",
+      "name": "Warlock",
+      "max": 1,
+      "cost": 30,
+      "stats": {
+        "M": 4,
+        "WS": 2,
+        "BS": 2,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 8
+      },
+      "specialRules": [
+        "Wizard"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "academic"
+      ],
+      "spellAccess": [
+        "lesser-magic"
+      ],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "cult-of-the-possessed",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "orc-mob",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "skaven-of-clan-eshin",
+        "undead",
+        "arabian-tomb-raiders",
+        "black-orcs",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "forest-goblins",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "skaven-of-clan-pestilens",
+        "trantios",
+        "tomb-guardians",
+        "black-dwarfs",
+        "bretonnian-chapel-guard",
+        "the_kurgan",
+        "merchant-caravans",
+        "night-goblins",
+        "norse-explorers",
+        "the-restless-dead",
+        "the-sons-of-hashut"
+      ]
+    },
+    {
+      "type": "arabian_merchant",
+      "name": "Arabian Merchant",
+      "max": 1,
+      "cost": 20,
+      "stats": {
+        "M": 4,
+        "WS": 2,
+        "BS": 2,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Haggle",
+        "Pawnbroker",
+        "Marketeer",
+        "Black Market",
+        "Foreign Wares",
+        "Fencer"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "academic"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "beast_hunter",
+      "name": "Beast Hunter",
+      "max": 1,
+      "cost": 35,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 4,
+        "S": 3,
+        "T": 4,
+        "W": 1,
+        "I": 4,
+        "A": 2,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Beastmen Vengeance",
+        "Skull Rack",
+        "Predator"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "strength"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "highwayman",
+      "name": "Highwayman",
+      "max": 1,
+      "cost": 35,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 3,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Expert Pistolier",
+        "Expert Rider",
+        "Unscrupulous"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "shooting",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "cult-of-the-possessed",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "skaven-of-clan-eshin",
+        "undead",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "forest-goblins",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "skaven-of-clan-pestilens",
+        "trantios",
+        "tomb-guardians",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "imperial_assassin",
+      "name": "Imperial Assassin",
+      "max": 1,
+      "cost": 40,
+      "stats": {
+        "M": 4,
+        "WS": 4,
+        "BS": 4,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 5,
+        "A": 2,
+        "Ld": 8
+      },
+      "specialRules": [
+        "Poisoner",
+        "Weapons Master"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "shooting",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "cult-of-the-possessed",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "undead",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "trantios",
+        "tomb-guardians",
+        "black-dwarfs",
+        "bretonnian-chapel-guard",
+        "the_kurgan",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-restless-dead",
+        "the-sons-of-hashut"
+      ]
+    },
+    {
+      "type": "roadwarden",
+      "name": "Roadwarden",
+      "max": 1,
+      "cost": 40,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 3,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Expert Rider",
+        "Lethal Marksman",
+        "Stern"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "shooting",
+        "strength"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "imperial-outriders",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
     },
     {
       "type": "tilean_marksman",
       "name": "Tilean Marksman",
       "max": 1,
       "cost": 30,
-      "stats": { "M": 4, "WS": 3, "BS": 4, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
-      "specialRules": [],
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 4,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 3,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Steady Hands",
+        "Dead Eye Shot"
+      ],
       "startingExp": 0,
-      "skillAccess": ["combat", "shooting", "speed"],
+      "skillAccess": [
+        "shooting"
+      ],
       "spellAccess": [],
-      "equipmentAccess": ["hand_to_hand", "missiles", "armour"],
-      "warbandRestrictions": []
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "cult-of-the-possessed",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "lustrian-reavers",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "bard",
+      "name": "Bard",
+      "max": 1,
+      "cost": 20,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 3,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Songster"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "academic",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "hochland-bandits",
+        "ostlander-mercenaries",
+        "pirates",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "big_game_hunter",
+      "name": "Big Game Hunter",
+      "max": 1,
+      "cost": 40,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 4,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Set Traps"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "shooting",
+        "academic"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "lustrian-reavers",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "black_orc_overseer",
+      "name": "Black Orc Overseer",
+      "max": 1,
+      "cost": 60,
+      "stats": {
+        "M": 4,
+        "WS": 4,
+        "BS": 3,
+        "S": 4,
+        "T": 4,
+        "W": 1,
+        "I": 2,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "I said 'shut it'",
+        "Who'se Da Man!"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "shooting",
+        "strength",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "orc-mob",
+        "black-orcs",
+        "forest-goblins",
+        "night-goblins",
+        "the-sons-of-hashut"
+      ]
+    },
+    {
+      "type": "bounty_hunter",
+      "name": "Bounty Hunter",
+      "max": 1,
+      "cost": 40,
+      "stats": {
+        "M": 4,
+        "WS": 4,
+        "BS": 3,
+        "S": 4,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 8
+      },
+      "specialRules": [
+        "Capture"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "shooting",
+        "strength",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "chameleon_skink",
+      "name": "Chameleon Skink",
+      "max": 1,
+      "cost": 70,
+      "stats": {
+        "M": 6,
+        "WS": 4,
+        "BS": 4,
+        "S": 4,
+        "T": 2,
+        "W": 1,
+        "I": 5,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Lizardmen Special Skills",
+        "Chameleon Skin",
+        "Infiltrator"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "shooting",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "lizardmen"
+      ]
+    },
+    {
+      "type": "clan_skryre_rat_ogre",
+      "name": "Clan Skryre Rat Ogre",
+      "max": 1,
+      "cost": 100,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 5,
+        "T": 5,
+        "W": 3,
+        "I": 1,
+        "A": 3,
+        "Ld": 10
+      },
+      "specialRules": [
+        "Large",
+        "Fear",
+        "Bio Machinery",
+        "Wyrdstone Powered",
+        "May not run",
+        "Immune to Poison",
+        "Warpfire Thrower",
+        "Jet of Flame",
+        "Unreliable"
+      ],
+      "startingExp": 0,
+      "skillAccess": [],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "skaven-of-clan-eshin",
+        "skaven-of-clan-pestilens"
+      ]
+    },
+    {
+      "type": "dark_elf_assassin",
+      "name": "Dark Elf Assassin",
+      "max": 1,
+      "cost": 70,
+      "stats": {
+        "M": 5,
+        "WS": 5,
+        "BS": 5,
+        "S": 4,
+        "T": 4,
+        "W": 1,
+        "I": 7,
+        "A": 1,
+        "Ld": 8
+      },
+      "specialRules": [
+        "Perfect Killer",
+        "Kindred Hatred"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "shooting",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "cult-of-the-possessed",
+        "skaven-of-clan-eshin",
+        "undead",
+        "dark-elves",
+        "forest-goblins",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "pirates",
+        "skaven-of-clan-pestilens",
+        "tomb-guardians",
+        "black-dwarfs",
+        "norse-explorers",
+        "the-restless-dead",
+        "the-sons-of-hashut",
+        "arabian-tomb-raiders"
+      ]
+    },
+    {
+      "type": "duellist",
+      "name": "Duellist",
+      "max": 1,
+      "cost": 35,
+      "stats": {
+        "M": 4,
+        "WS": 4,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 2,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Darting Steel"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "shooting"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "cult-of-the-possessed",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "forest-goblins",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "dwarf_pathfinder",
+      "name": "Dwarf Pathfinder",
+      "max": 1,
+      "cost": 35,
+      "stats": {
+        "M": 3,
+        "WS": 4,
+        "BS": 3,
+        "S": 3,
+        "T": 4,
+        "W": 1,
+        "I": 2,
+        "A": 1,
+        "Ld": 9
+      },
+      "specialRules": [
+        "Explorer",
+        "Hard to Kill",
+        "Hard Head",
+        "Hate Orcs and Goblins",
+        "Elf Grudge",
+        "Magic"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "shooting"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-restless-dead"
+      ]
     },
     {
       "type": "dwarf_treasure_hunter",
       "name": "Dwarf Treasure Hunter",
       "max": 1,
-      "cost": 25,
-      "stats": { "M": 3, "WS": 4, "BS": 3, "S": 3, "T": 4, "W": 1, "I": 2, "A": 1, "Ld": 9 },
-      "specialRules": ["Hard to Kill", "Thick Skulled"],
-      "startingExp": 0,
-      "skillAccess": ["combat", "shooting", "strength"],
-      "spellAccess": [],
-      "equipmentAccess": ["hand_to_hand", "missiles", "armour"],
-      "warbandRestrictions": ["skaven", "cult_of_the_possessed", "undead", "restless_dead"]
-    },
-    {
-      "type": "hired_swordsman",
-      "name": "Hired Swordsman",
-      "max": 1,
-      "cost": 15,
-      "stats": { "M": 4, "WS": 3, "BS": 3, "S": 3, "T": 3, "W": 1, "I": 3, "A": 1, "Ld": 7 },
-      "specialRules": [],
-      "startingExp": 0,
-      "skillAccess": ["combat", "speed"],
-      "spellAccess": [],
-      "equipmentAccess": ["hand_to_hand", "armour"],
-      "warbandRestrictions": []
-    },
-    {
-      "type": "imperial_assassin",
-      "name": "Imperial Assassin",
-      "max": 1,
-      "cost": 50,
-      "stats": { "M": 4, "WS": 4, "BS": 4, "S": 3, "T": 3, "W": 1, "I": 5, "A": 2, "Ld": 8 },
-      "specialRules": ["Dodge", "Stealth"],
-      "startingExp": 0,
-      "skillAccess": ["combat", "shooting", "speed"],
-      "spellAccess": [],
-      "equipmentAccess": ["hand_to_hand", "missiles"],
-      "warbandRestrictions": ["undead", "cult_of_the_possessed", "skaven", "restless_dead"]
-    },
-    {
-      "type": "dwarf_troll_slayer",
-      "name": "Dwarf Troll Slayer",
-      "max": 1,
-      "cost": 25,
-      "stats": { "M": 3, "WS": 4, "BS": 3, "S": 3, "T": 4, "W": 1, "I": 2, "A": 1, "Ld": 9 },
-      "specialRules": ["Deathwish", "Hard to Kill", "Hard Head"],
-      "startingExp": 0,
-      "skillAccess": ["combat", "strength", "troll_slayer_special"],
-      "spellAccess": [],
-      "equipmentAccess": ["hand_to_hand"],
-      "warbandAllowList": [
-        "reikland", "middenheim", "marienburg", "witch_hunters", "sisters_of_sigmar",
-        "averlander", "ostlander", "kislevites", "bretonnians", "tileans",
-        "hochland_bandits", "gunnery_school_of_nuln", "imperial_outriders",
-        "outlaws_of_stirwood", "pirates", "norse_explorers", "mootlanders",
-        "pit_fighters",
-        "dwarf_treasure_hunters", "dwarf_rangers",
-        "dark_elves", "shadow_warriors"
+      "cost": 55,
+      "stats": {
+        "M": 3,
+        "WS": 5,
+        "BS": 4,
+        "S": 3,
+        "T": 4,
+        "W": 1,
+        "I": 2,
+        "A": 1,
+        "Ld": 9
+      },
+      "specialRules": [
+        "Hard to Kill",
+        "Hard Head",
+        "Hates Orcs & Goblins",
+        "Mining Pick",
+        "Lantern Rig",
+        "Treasure Maps"
       ],
-      "hiringNotes": "May be hired by Mercenaries and Witch Hunters. Warbands that include Elves may hire but must pay 20gc upkeep per battle instead of 10gc."
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "strength"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "witch-hunters",
+        "hochland-bandits",
+        "ostlander-mercenaries",
+        "pirates",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "elf_mage",
+      "name": "Elf Mage",
+      "max": 1,
+      "cost": 45,
+      "stats": {
+        "M": 5,
+        "WS": 4,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 2,
+        "I": 6,
+        "A": 1,
+        "Ld": 8
+      },
+      "specialRules": [
+        "Fey",
+        "Sorcery",
+        "Wanderer",
+        "Wizard"
+      ],
+      "startingExp": 0,
+      "skillAccess": [],
+      "spellAccess": [
+        "spells-of-the-djedhi"
+      ],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "hochland-bandits",
+        "ostlander-mercenaries",
+        "pirates",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "gaoler",
+      "name": "Gaoler",
+      "max": 1,
+      "cost": 30,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 2,
+        "S": 4,
+        "T": 4,
+        "W": 2,
+        "I": 3,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Torturer’s grapple",
+        "Devout",
+        "Inured to pain",
+        "Hatred"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "strength"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "witch-hunters",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "halfling_thief",
+      "name": "Halfling Thief",
+      "max": 1,
+      "cost": 25,
+      "stats": {
+        "M": 4,
+        "WS": 2,
+        "BS": 4,
+        "S": 2,
+        "T": 2,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Infiltrator",
+        "Pick Locks",
+        "Cutpurse",
+        "Uneasy Ally"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "shooting",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "dwarf-rangers",
+        "hochland-bandits",
+        "ostlander-mercenaries",
+        "pirates",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "human_scout",
+      "name": "Human Scout",
+      "max": 1,
+      "cost": 10,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 6
+      },
+      "specialRules": [
+        "Not a Fighter"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "shooting",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "skaven-of-clan-eshin",
+        "undead",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "skaven-of-clan-pestilens",
+        "trantios",
+        "tomb-guardians",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "kislev_ranger",
+      "name": "Kislev Ranger",
+      "max": 1,
+      "cost": 30,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 4,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Heart Strike",
+        "Hunter’s Cloak",
+        "Loner",
+        "Seeker"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "shooting",
+        "academic",
+        "strength",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "witch-hunters",
+        "dwarf-rangers",
+        "hochland-bandits",
+        "ostlander-mercenaries",
+        "pirates",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "mule_skinner",
+      "name": "Mule Skinner",
+      "max": 1,
+      "cost": 35,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 3,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Animal Handler",
+        "Whip",
+        "Disarm",
+        "Note"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "academic",
+        "strength"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "forest-goblins",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "nomad_scout",
+      "name": "Nomad Scout",
+      "max": 1,
+      "cost": 30,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 4,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Son of the Desert"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "shooting",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "cult-of-the-possessed",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "skaven-of-clan-eshin",
+        "undead",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "forest-goblins",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "skaven-of-clan-pestilens",
+        "trantios",
+        "tomb-guardians",
+        "black-dwarfs",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-restless-dead",
+        "the-sons-of-hashut"
+      ]
+    },
+    {
+      "type": "norse_shaman",
+      "name": "Norse Shaman",
+      "max": 1,
+      "cost": 45,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 2,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 8
+      },
+      "specialRules": [
+        "Runes"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "academic"
+      ],
+      "spellAccess": [
+        "norse-runes"
+      ],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "cult-of-the-possessed",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "ostlander-mercenaries",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "the_kurgan",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-sons-of-hashut"
+      ]
+    },
+    {
+      "type": "old_prospector",
+      "name": "Old Prospector",
+      "max": 1,
+      "cost": 2,
+      "stats": {
+        "M": 4,
+        "WS": 2,
+        "BS": 2,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 3,
+        "A": 1,
+        "Ld": 9
+      },
+      "specialRules": [
+        "Hardened",
+        "Finders Keepers",
+        "Old Coot"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "strength",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "cult-of-the-possessed",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "skaven-of-clan-eshin",
+        "undead",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "forest-goblins",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "skaven-of-clan-pestilens",
+        "trantios",
+        "tomb-guardians",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "pathfinder",
+      "name": "Pathfinder",
+      "max": 1,
+      "cost": 60,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 4,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 8
+      },
+      "specialRules": [
+        "Lay of the Land",
+        "Knowledge of Myths and Legends"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "shooting",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "cult-of-the-possessed",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "skaven-of-clan-eshin",
+        "undead",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "forest-goblins",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "skaven-of-clan-pestilens",
+        "trantios",
+        "tomb-guardians",
+        "black-dwarfs",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-restless-dead",
+        "the-sons-of-hashut"
+      ]
+    },
+    {
+      "type": "priest_of_morr",
+      "name": "Priest Of Morr",
+      "max": 1,
+      "cost": 0,
+      "stats": {
+        "M": 4,
+        "WS": 2,
+        "BS": 2,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 9
+      },
+      "specialRules": [
+        "Loner",
+        "Funerary Rites",
+        "Scythe"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "academic",
+        "speed"
+      ],
+      "spellAccess": [
+        "funerary-rites"
+      ],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "hochland-bandits",
+        "ostlander-mercenaries",
+        "pirates",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "runesmith_journeyman",
+      "name": "Runesmith Journeyman",
+      "max": 1,
+      "cost": 30,
+      "stats": {
+        "M": 3,
+        "WS": 4,
+        "BS": 3,
+        "S": 3,
+        "T": 4,
+        "W": 1,
+        "I": 2,
+        "A": 1,
+        "Ld": 9
+      },
+      "specialRules": [
+        "Runesmith",
+        "Armourer",
+        "Armour",
+        "Hate Orcs and Goblins",
+        "Hard to Kill",
+        "Hard Head",
+        "Rune Use",
+        "Durable"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "strength"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "witch-hunters",
+        "hochland-bandits",
+        "ostlander-mercenaries",
+        "pirates",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "shadow_warrior",
+      "name": "Shadow Warrior",
+      "max": 1,
+      "cost": 35,
+      "stats": {
+        "M": 5,
+        "WS": 4,
+        "BS": 4,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 6,
+        "A": 1,
+        "Ld": 8
+      },
+      "specialRules": [
+        "Hates Dark Elves",
+        "Excellent Sight",
+        "Bitter Enemies",
+        "Infiltration"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "shooting"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "snake_charmer",
+      "name": "Snake Charmer",
+      "max": 1,
+      "cost": 40,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 3,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Snake Charmer",
+        "Immune to poison",
+        "Venomous",
+        "Animals",
+        "Snake hunter"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "academic",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "thief",
+      "name": "Thief",
+      "max": 1,
+      "cost": 30,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Thief's Cloak",
+        "Tea-Leaf!"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "cult-of-the-possessed",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "skaven-of-clan-eshin",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "forest-goblins",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "skaven-of-clan-pestilens",
+        "trantios",
+        "black-dwarfs",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-sons-of-hashut",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "tomb_robber",
+      "name": "Tomb Robber",
+      "max": 1,
+      "cost": 30,
+      "stats": {
+        "M": 4,
+        "WS": 4,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 5,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Explorer",
+        "Traps",
+        "Excellent Reflexes"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "shooting",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "warrior_priest_of_sigmar",
+      "name": "Warrior Priest Of Sigmar",
+      "max": 1,
+      "cost": 40,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 8
+      },
+      "specialRules": [
+        "Prayers"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "academic"
+      ],
+      "spellAccess": [
+        "prayers-of-sigmar"
+      ],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "witch",
+      "name": "Witch",
+      "max": 1,
+      "cost": 30,
+      "stats": {
+        "M": 4,
+        "WS": 2,
+        "BS": 2,
+        "S": 2,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Wizard",
+        "Recluse",
+        "Potions",
+        "Reluctant"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "academic"
+      ],
+      "spellAccess": [
+        "charms-and-hexes"
+      ],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "cult-of-the-possessed",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "skaven-of-clan-eshin",
+        "undead",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "forest-goblins",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "skaven-of-clan-pestilens",
+        "trantios",
+        "tomb-guardians",
+        "black-dwarfs",
+        "bretonnian-chapel-guard",
+        "the_kurgan",
+        "merchant-caravans",
+        "night-goblins",
+        "norse-explorers",
+        "the-restless-dead",
+        "the-sons-of-hashut"
+      ]
+    },
+    {
+      "type": "witch_hunter",
+      "name": "Witch Hunter",
+      "max": 1,
+      "cost": 30,
+      "stats": {
+        "M": 4,
+        "WS": 4,
+        "BS": 4,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 8
+      },
+      "specialRules": [
+        "Burn the Witch",
+        "In Sigmar’s name",
+        "Sigmar’s reward"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "shooting",
+        "academic",
+        "strength",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "bretonnians",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "trantios",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "wolf_priest_of_ulric",
+      "name": "Wolf Priest of Ulric",
+      "max": 1,
+      "cost": 0,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 3,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Hatred",
+        "Wolf Companion",
+        "Animals"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "academic",
+        "strength",
+        "speed"
+      ],
+      "spellAccess": [
+        "prayers-of-ulric"
+      ],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "middenheim_mercenaries"
+      ]
     },
     {
       "type": "bone_goliath",
       "name": "Bone Goliath",
       "max": 1,
       "cost": 225,
-      "stats": { "M": 5, "WS": 3, "BS": 0, "S": 5, "T": 5, "W": 3, "I": 2, "A": 3, "Ld": 6 },
-      "specialRules": ["Cause Fear", "May Not Run", "Immune to Psychology", "Immune to Poison", "Undead Construct", "Assembly", "Large", "No Pain", "Mindless"],
+      "stats": {
+        "M": 5,
+        "WS": 3,
+        "BS": 0,
+        "S": 5,
+        "T": 5,
+        "W": 3,
+        "I": 2,
+        "A": 3,
+        "Ld": 6
+      },
+      "specialRules": [
+        "Cause Fear",
+        "May not run",
+        "Immune to Psychology",
+        "Immune to Poison",
+        "Undead Construct",
+        "Assembly",
+        "Large",
+        "No Pain",
+        "Mindless"
+      ],
       "startingExp": 0,
       "skillAccess": [],
       "spellAccess": [],
-      "equipmentAccess": [],
-      "warbandRestrictions": [],
-      "warbandAllowList": ["restless_dead"]
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "cathayan_merchant",
+      "name": "Cathayan Merchant",
+      "max": 1,
+      "cost": 20,
+      "stats": {
+        "M": 4,
+        "WS": 2,
+        "BS": 2,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Haggle",
+        "Pawnbroker",
+        "Marketeer",
+        "Black Market",
+        "Exotic Wares"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "academic"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "cult-of-the-possessed",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "trantios",
+        "black-dwarfs",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-sons-of-hashut",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "chaos_centaur",
+      "name": "Chaos Centaur",
+      "max": 1,
+      "cost": 65,
+      "stats": {
+        "M": 8,
+        "WS": 4,
+        "BS": 3,
+        "S": 4,
+        "T": 3,
+        "W": 1,
+        "I": 3,
+        "A": "1(2)",
+        "Ld": 7
+      },
+      "specialRules": [
+        "Drunken",
+        "Woodland Dwelling",
+        "Trample"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "strength"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "beastmen-raiders",
+        "black-dwarfs",
+        "maneaters",
+        "the_kurgan",
+        "norse-explorers",
+        "the-sons-of-hashut"
+      ]
+    },
+    {
+      "type": "coachman",
+      "name": "Coachman",
+      "max": 1,
+      "cost": 20,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Driver",
+        "Handyman"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "cult-of-the-possessed",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "undead",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "tomb-guardians",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "grave_robber",
+      "name": "Grave Robber",
+      "max": 1,
+      "cost": 45,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 6
+      },
+      "specialRules": [
+        "Hatred",
+        "Grave Robbing"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "undead",
+        "tomb-guardians",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "hobgoblin_scout",
+      "name": "Hobgoblin Scout",
+      "max": 1,
+      "cost": 45,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 3,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Ride",
+        "Loner",
+        "Traitor"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "shooting"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "black-dwarfs",
+        "maneaters",
+        "the-sons-of-hashut"
+      ]
+    },
+    {
+      "type": "ninja",
+      "name": "Ninja",
+      "max": 1,
+      "cost": 70,
+      "stats": {
+        "M": 4,
+        "WS": 4,
+        "BS": 4,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 5,
+        "A": 2,
+        "Ld": 8
+      },
+      "specialRules": [
+        "Strictly Business",
+        "Secrecy"
+      ],
+      "startingExp": 0,
+      "skillAccess": [],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "cult-of-the-possessed",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "undead",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "tomb-guardians",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "pyromaniac",
+      "name": "Pyromaniac",
+      "max": 1,
+      "cost": 25,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 3,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Crazed Firestarter",
+        "Rockets"
+      ],
+      "startingExp": 0,
+      "skillAccess": [],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "hochland-bandits",
+        "ostlander-mercenaries",
+        "pirates",
+        "merchant-caravans"
+      ]
+    },
+    {
+      "type": "swordsmith",
+      "name": "Swordsmith",
+      "max": 1,
+      "cost": 60,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 4,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Master Craftsman"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "academic",
+        "strength"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "hochland-bandits",
+        "ostlander-mercenaries",
+        "pirates",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "beggar",
+      "name": "Beggar",
+      "max": 1,
+      "cost": 10,
+      "stats": {
+        "M": 4,
+        "WS": 1,
+        "BS": 1,
+        "S": 2,
+        "T": 2,
+        "W": 1,
+        "I": 3,
+        "A": 1,
+        "Ld": 5
+      },
+      "specialRules": [
+        "Scrounge",
+        "Not a Threat"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "cult-of-the-possessed",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "skaven-of-clan-eshin",
+        "undead",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "forest-goblins",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "skaven-of-clan-pestilens",
+        "trantios",
+        "tomb-guardians",
+        "black-dwarfs",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-restless-dead",
+        "the-sons-of-hashut"
+      ]
+    },
+    {
+      "type": "chaos_fury",
+      "name": "Chaos Fury",
+      "max": 1,
+      "cost": 30,
+      "stats": {
+        "M": 4,
+        "WS": 4,
+        "BS": 3,
+        "S": 4,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 2,
+        "Ld": 10
+      },
+      "specialRules": [
+        "Fear",
+        "Daemonic Flesh",
+        "Daemonic Mind",
+        "Daemonic Instability",
+        "Fly",
+        "Malicious"
+      ],
+      "startingExp": 0,
+      "skillAccess": [],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "beastmen-raiders",
+        "carnival-of-chaos",
+        "cult-of-the-possessed",
+        "black-dwarfs",
+        "the_kurgan",
+        "norse-explorers",
+        "the-sons-of-hashut"
+      ]
+    },
+    {
+      "type": "cursed_hillman",
+      "name": "Cursed Hillman",
+      "max": 1,
+      "cost": 60,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 3,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Hunter",
+        "Thin Flesh",
+        "Lycanthrope"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "shooting",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "beastmen-raiders",
+        "cult-of-the-possessed",
+        "undead",
+        "tomb-guardians",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "dark_mage",
+      "name": "Dark Mage",
+      "max": 1,
+      "cost": 35,
+      "stats": {
+        "M": 4,
+        "WS": 2,
+        "BS": 2,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 3,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Wizard",
+        "Despise Despoilers",
+        "Self Assured",
+        "Dark Magic"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "academic"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "battle-monks-of-cathay",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "dwarf_slayer_pirate",
+      "name": "Dwarf Slayer Pirate",
+      "max": 1,
+      "cost": 30,
+      "stats": {
+        "M": 3,
+        "WS": 4,
+        "BS": 3,
+        "S": 3,
+        "T": 4,
+        "W": 1,
+        "I": 2,
+        "A": 1,
+        "Ld": 9
+      },
+      "specialRules": [
+        "Deathwish",
+        "Hard to Kill",
+        "Hard Head",
+        "Festooned with Pistols",
+        "Raging Drunk"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "shooting"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "ostlander-mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "witch-hunters",
+        "hochland-bandits",
+        "pirates",
+        "remasens",
+        "trantios",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "emissary_of_chaos",
+      "name": "Emissary of Chaos",
+      "max": 1,
+      "cost": 50,
+      "stats": {
+        "M": 4,
+        "WS": 5,
+        "BS": 3,
+        "S": 4,
+        "T": 4,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 9
+      },
+      "specialRules": [
+        "Special Skills"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "academic",
+        "strength"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "beastmen-raiders",
+        "carnival-of-chaos",
+        "cult-of-the-possessed",
+        "dark-elves",
+        "norse-explorers"
+      ]
+    },
+    {
+      "type": "estalian_diestro",
+      "name": "Estalian Diestro",
+      "max": 1,
+      "cost": 35,
+      "stats": {
+        "M": 4,
+        "WS": 4,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 8
+      },
+      "specialRules": [
+        "Rapier",
+        "Main Gauche"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "shadow-warriors",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "fallen_sister",
+      "name": "The Fallen Sister",
+      "max": 1,
+      "cost": 55,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 4,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 8
+      },
+      "specialRules": [
+        "Wizard",
+        "Warrior Wizard",
+        "Ashamed and Afraid"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "strength",
+        "speed"
+      ],
+      "spellAccess": [
+        "lesser-magic"
+      ],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "cult-of-the-possessed",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "goblin_lantern_bearer",
+      "name": "Goblin Lantern Bearer",
+      "max": 1,
+      "cost": 15,
+      "stats": {
+        "M": 4,
+        "WS": 2,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 5
+      },
+      "specialRules": [
+        "Smart (for a Goblin)",
+        "Very Lucky",
+        "Small Size"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "cult-of-the-possessed",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "orc-mob",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "skaven-of-clan-eshin",
+        "undead",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "forest-goblins",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "skaven-of-clan-pestilens",
+        "trantios",
+        "tomb-guardians",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "night-goblins",
+        "norse-explorers",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "gravesman",
+      "name": "Gravesman",
+      "max": 1,
+      "cost": 25,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 3,
+        "A": 1,
+        "Ld": 8
+      },
+      "specialRules": [
+        "He’s o’er dere"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "strength"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "skaven-of-clan-eshin",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "skaven-of-clan-pestilens",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "halfling_knight",
+      "name": "Halfling Knight",
+      "max": 1,
+      "cost": 20,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 3,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Slay Large Creature"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "imperial_tactician",
+      "name": "Imperial Tactician",
+      "max": 1,
+      "cost": 40,
+      "stats": {
+        "M": "4(3)",
+        "WS": 4,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 5,
+        "A": 1,
+        "Ld": 9
+      },
+      "specialRules": [
+        "Expert Tactician",
+        "Read the Battle"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "strength"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "trantios",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "knight_of_the_white_wolf",
+      "name": "Knight of the White Wolf",
+      "max": 1,
+      "cost": 55,
+      "stats": {
+        "M": 4,
+        "WS": 4,
+        "BS": 3,
+        "S": 4,
+        "T": 4,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 9
+      },
+      "specialRules": [
+        "Pride of Ar-Ulric",
+        "Cavalryman",
+        "Among Wolves"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "strength"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "hochland-bandits",
+        "ostlander-mercenaries",
+        "pirates",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "ninja_gnoblar",
+      "name": "Ninja Gnoblar",
+      "max": 1,
+      "cost": 35,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 6
+      },
+      "specialRules": [
+        "Stealthy",
+        "Rooftop to Rooftop"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "shooting",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "maneaters",
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "skaven-of-clan-eshin",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dark-elves",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "skaven-of-clan-pestilens",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "norse-explorers",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "ogre_slave_master",
+      "name": "Ogre Slave Master",
+      "max": 1,
+      "cost": 90,
+      "stats": {
+        "M": 6,
+        "WS": 3,
+        "BS": 2,
+        "S": 4,
+        "T": 4,
+        "W": 3,
+        "I": 4,
+        "A": 2,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Slave Master",
+        "Fear",
+        "Large Target"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "strength"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "beastmen-raiders",
+        "carnival-of-chaos",
+        "cult-of-the-possessed"
+      ]
+    },
+    {
+      "type": "slaver",
+      "name": "Slaver",
+      "max": 1,
+      "cost": 20,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 4,
+        "A": 1,
+        "Ld": 8
+      },
+      "specialRules": [
+        "Slaver"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "strength"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "cult-of-the-possessed",
+        "skaven-of-clan-eshin",
+        "undead",
+        "dark-elves",
+        "skaven-of-clan-pestilens",
+        "tomb-guardians",
+        "norse-explorers",
+        "the-restless-dead",
+        "arabian-tomb-raiders"
+      ]
+    },
+    {
+      "type": "swashbuckler",
+      "name": "Swashbuckler",
+      "max": 1,
+      "cost": 30,
+      "stats": {
+        "M": 4,
+        "WS": 4,
+        "BS": 3,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 5,
+        "A": 1,
+        "Ld": 8
+      },
+      "specialRules": [
+        "Acrobatic",
+        "Nimble",
+        "Charismatic"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "combat",
+        "shooting",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "ungor_trapper",
+      "name": "Ungor Trapper",
+      "max": 1,
+      "cost": 20,
+      "stats": {
+        "M": 5,
+        "WS": 3,
+        "BS": 4,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 3,
+        "A": 1,
+        "Ld": 6
+      },
+      "specialRules": [
+        "Set Traps",
+        "Hunter’s Eye",
+        "Excellent Sight",
+        "Just a Twit"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "shooting",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "beastmen-raiders",
+        "cult-of-the-possessed",
+        "the_kurgan",
+        "norse-explorers"
+      ]
+    },
+    {
+      "type": "weaponsmith",
+      "name": "Weaponsmith",
+      "max": 1,
+      "cost": 30,
+      "stats": {
+        "M": 4,
+        "WS": 3,
+        "BS": 3,
+        "S": 4,
+        "T": 3,
+        "W": 1,
+        "I": 3,
+        "A": 1,
+        "Ld": 7
+      },
+      "specialRules": [
+        "Maintenance"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "strength",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
+    },
+    {
+      "type": "wood_elf_hunter",
+      "name": "Wood Elf Hunter",
+      "max": 1,
+      "cost": 50,
+      "stats": {
+        "M": 5,
+        "WS": 4,
+        "BS": 5,
+        "S": 3,
+        "T": 3,
+        "W": 1,
+        "I": 6,
+        "A": 1,
+        "Ld": 8
+      },
+      "specialRules": [
+        "Stalk",
+        "Hunted",
+        "Keen Eyed"
+      ],
+      "startingExp": 0,
+      "skillAccess": [
+        "shooting",
+        "speed"
+      ],
+      "spellAccess": [],
+      "equipmentAccess": [
+        "hand_to_hand",
+        "missiles",
+        "armour"
+      ],
+      "warbandAllowList": [
+        "averlander-mercenaries",
+        "dwarf-treasure-hunters",
+        "kislevites",
+        "marienburg_mercenaries",
+        "miragleans",
+        "middenheim_mercenaries",
+        "reikland_mercenaries",
+        "battle-monks-of-cathay",
+        "sisters-of-sigmar",
+        "witch-hunters",
+        "arabian-tomb-raiders",
+        "bretonnians",
+        "dwarf-rangers",
+        "gunnery-school-of-nuln",
+        "hochland-bandits",
+        "horned-hunters",
+        "lizardmen",
+        "mootlanders",
+        "ostlander-mercenaries",
+        "outlaws-of-stirwood-forest",
+        "pirates",
+        "pit-fighters",
+        "remasens",
+        "shadow-warriors",
+        "trantios",
+        "bretonnian-chapel-guard",
+        "merchant-caravans",
+        "the-restless-dead"
+      ]
     }
   ]
 }

--- a/docs/superpowers/plans/2026-04-01-hired-swords-uncle-mel-migration.md
+++ b/docs/superpowers/plans/2026-04-01-hired-swords-uncle-mel-migration.md
@@ -1,0 +1,473 @@
+# Hired Swords Uncle-Mel Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate `data/hired_swords.json` from a hand-maintained file to one fully produced by the nightly sync script from Uncle-Mel's `hiredSwords.json`. No fields are preserved from the old hand-maintained file — everything is derived from Uncle-Mel's data.
+
+**Architecture:** Add a `transformHiredSwords()` function to `scripts/sync-mordheim-data.js` that converts Uncle-Mel's keyed object format into our flat `{ hiredSwords: [] }` array. Wire it into the existing sync pipeline. `js/data.js` requires no changes — it already reads the file and supports `warbandAllowList`.
+
+**Tech Stack:** Node.js, `gh` CLI for GitHub API access, existing `ghRaw()` / `mapStatKeys()` utilities in sync script.
+
+---
+
+## Field mapping: Uncle-Mel → our format
+
+| Uncle-Mel field | Our field | Transformation |
+|----------------|-----------|----------------|
+| key (e.g. `"dwarf-troll-slayer"`) | `type` | `key.replace(/-/g, '_')` |
+| `name` | `name` | as-is |
+| `cost` | `cost` | `parseInt(v.cost) \|\| 0` |
+| (absent) | `max` | hardcode `1` |
+| `statblock` (lowercase keys) | `stats` | `mapStatKeys(v.statblock)` |
+| `specialRules[].rulename` | `specialRules` | extract rulename strings |
+| (absent) | `startingExp` | hardcode `0` |
+| `skillAccess` object | `skillAccess` | extract truthy keys, exclude `"special"` |
+| (derived) | `spellAccess` | lookup via `HIRED_SWORD_SPELL_ACCESS_MAP` keyed on the entry key; default `[]` |
+| (derived) | `equipmentAccess` | always `["hand_to_hand", "missiles", "armour"]` — Uncle-Mel has no category data |
+| `permittedWarbands[]` | `warbandAllowList` | map display names → warband IDs via `HIRED_SWORD_WARBAND_NAME_MAP` |
+
+**Note on `warbandAllowList`:** `DataService.getAvailableHiredSwords()` already checks `warbandAllowList` first. Uncle-Mel's `permittedWarbands` maps directly to this field. The old `warbandRestrictions` deny-list is dropped.
+
+**Note on `spellAccess`:** Uncle-Mel's `skillText` and `specialRules` contain explicit spell list references (e.g. "Lesser Magic", "Norse Runes chart", "Prayers of Sigmar"). These are extracted into a static `HIRED_SWORD_SPELL_ACCESS_MAP`. Only 9 hired swords are casters.
+
+**Note on `equipmentAccess`:** Uncle-Mel's `equipment` field is a text description, not categories. The UI uses `equipmentAccess` to show equipment picker tabs. Defaulting to all three shows everything; the actual items selectable are still constrained by `allowedEquipment` (which hired swords don't use — they use a free-form picker). Defaulting to all three is correct.
+
+---
+
+## Files
+
+- **Modify:** `scripts/sync-mordheim-data.js` — add two maps, `transformHiredSwords()`, `validateHiredSwords()`, processing block in `main()`
+- **Replace (via sync):** `data/hired_swords.json` — regenerated; old hand-maintained file is deleted after successful sync
+
+---
+
+## Task 1: Add constants — TRACKED_FILES entry, warband name map, spell access map
+
+**Files:**
+- Modify: `scripts/sync-mordheim-data.js`
+
+- [ ] **Step 1: Add `hiredSwords.json` to TRACKED_FILES**
+
+Find `TRACKED_FILES` (line ~32) and add the entry:
+
+```js
+const TRACKED_FILES = [
+  { key: 'equipment',   path: 'data/mergedEquipment.json' },
+  { key: 'skills',      path: 'data/skills.json'          },
+  { key: 'magic',       path: 'data/magic.json'           },
+  { key: 'hiredSwords', path: 'data/hiredSwords.json'     },
+];
+```
+
+- [ ] **Step 2: Add `HIRED_SWORD_WARBAND_NAME_MAP` after `WARBAND_SPECIAL_SKILL_CATEGORIES` (line ~139)**
+
+```js
+// Maps Uncle-Mel permittedWarbands display names → our warband IDs (data/warbands.json)
+const HIRED_SWORD_WARBAND_NAME_MAP = {
+  'Arabian Tomb Raiders':             'arabian-tomb-raiders',
+  'Averlanders':                      'averlander-mercenaries',
+  'Battle Monks of Cathay':           'battle-monks-of-cathay',
+  'Beastmen Raiders':                 'beastmen-raiders',
+  'Black Dwarfs':                     'black-dwarfs',
+  'Black Orcs':                       'black-orcs',
+  'Bretonnian Chapel Guard':          'bretonnian-chapel-guard',
+  'Bretonnian Knights':               'bretonnians',
+  'Carnival of Chaos':                'carnival-of-chaos',
+  'Cult of the Possessed':            'cult-of-the-possessed',
+  'Dark Elves':                       'dark-elves',
+  'Dreamwalkers, Cult Of Morr':       'the-restless-dead',
+  'Druchii':                          'dark-elves',
+  'Dwarf Rangers':                    'dwarf-rangers',
+  'Dwarf Slayer Cult':                'dwarf-treasure-hunters',
+  'Dwarf Treasure Hunters':           'dwarf-treasure-hunters',
+  'Forest Goblins':                   'forest-goblins',
+  'Grave Robbers':                    'arabian-tomb-raiders',
+  'Gunnery School of Nuln':           'gunnery-school-of-nuln',
+  'Hochland Bandits':                 'hochland-bandits',
+  'Horned Hunters':                   'horned-hunters',
+  'Imperial Outriders':               'imperial-outriders',
+  'Kislevites':                       'kislevites',
+  'Lizardmen':                        'lizardmen',
+  'Lustrian Reavers':                 'lustrian-reavers',
+  'Maneaters':                        'maneaters',
+  'Marauders of Chaos':               'the_kurgan',
+  'Marienburgers':                    'marienburg_mercenaries',
+  'Merchant Caravans':                'merchant-caravans',
+  'Middenheimers':                    'middenheim_mercenaries',
+  'Miragleans':                       'miragleans',
+  'Mootlanders':                      'mootlanders',
+  'Night Goblins':                    'night-goblins',
+  'Night Goblins (web)':              'night-goblins',
+  'Nipponese Expedition':             'battle-monks-of-cathay',
+  'Norse Explorers':                  'norse-explorers',
+  'Orc Mob':                          'orc-mob',
+  'Ostermarkers':                     'ostlander-mercenaries',
+  'Ostlanders':                       'ostlander-mercenaries',
+  'Outlaws of Stirwood Forest, The':  'outlaws-of-stirwood-forest',
+  'Pirates':                          'pirates',
+  'Pit Fighters':                     'pit-fighters',
+  'Reiklanders':                      'reikland_mercenaries',
+  'Remasens':                         'remasens',
+  'Shadow Warriors':                  'shadow-warriors',
+  'Sisters of Sigmar':                'sisters-of-sigmar',
+  'Skaven':                           'skaven-of-clan-eshin',
+  'Skaven of Clan Pestilens':         'skaven-of-clan-pestilens',
+  'Sons of Hashut:':                  'the-sons-of-hashut',
+  'The Restless Dead':                'the-restless-dead',
+  'The Sons of Hashut':               'the-sons-of-hashut',
+  'Tileans':                          'trantios',
+  'Tomb Guardians':                   'tomb-guardians',
+  'Trantios':                         'trantios',
+  'Undead':                           'undead',
+  'Witch Hunters':                    'witch-hunters',
+  'Mazzalupo':                        'miragleans',
+};
+```
+
+- [ ] **Step 3: Add `HIRED_SWORD_SPELL_ACCESS_MAP` immediately after the warband name map**
+
+Casters identified from Uncle-Mel's `skillText` and `specialRules`. Non-casters get `[]` by default.
+
+```js
+// Maps hired sword entry key → spell list IDs
+// Derived from Uncle-Mel skillText links and specialRules.
+// Only entries with at least one spell list are included; all others default to [].
+const HIRED_SWORD_SPELL_ACCESS_MAP = {
+  'warlock':                  ['lesser-magic'],
+  'elf-mage':                 ['spells-of-the-djedhi'],
+  'norse-shaman':             ['norse-runes'],
+  'warrior-priest-of-sigmar': ['prayers-of-sigmar'],
+  'witch':                    ['charms-and-hexes'],
+  'fallen-sister':            ['lesser-magic'],
+  'priest-of-morr':           ['funerary-rites'],
+  'wolf-priest-of-ulric':     ['prayers-of-ulric'],
+  // dark-mage uses "Dark Magic list" which has no matching entry in magic.json;
+  // the UI hasSpellAccess() fallback detects them via the "Wizard" special rule.
+};
+```
+
+- [ ] **Step 4: Verify the file still parses**
+
+```bash
+node -e "require('./scripts/sync-mordheim-data.js'); console.log('OK')" 2>&1 | head -5
+```
+
+Expected: `OK` (or the script's normal startup output, not a syntax error)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/sync-mordheim-data.js
+git commit -m "chore: add hiredSwords tracking and name/spell maps to sync script"
+```
+
+---
+
+## Task 2: Add `transformHiredSwords()` function
+
+**Files:**
+- Modify: `scripts/sync-mordheim-data.js`
+
+- [ ] **Step 1: Add the function after `transformWarbands()` (before `// ─── Validators`)**
+
+```js
+// ─── Hired Swords transformer ─────────────────────────────────────────────
+//
+// Source: hiredSwords.json — keyed object { "dwarf-troll-slayer": { ... } }
+// Ours:   hired_swords.json — { hiredSwords: [] }
+//
+// Key field mappings:
+//   key                       → type (hyphens → underscores)
+//   cost                      → cost (parseInt)
+//   statblock (lowercase)     → stats (uppercase via mapStatKeys)
+//   specialRules[].rulename   → specialRules (flat string array)
+//   skillAccess { k: bool }   → skillAccess (truthy keys, excluding "special")
+//   permittedWarbands[]       → warbandAllowList (via HIRED_SWORD_WARBAND_NAME_MAP)
+//   (absent)                  → spellAccess (via HIRED_SWORD_SPELL_ACCESS_MAP; default [])
+//   (absent)                  → equipmentAccess (always ["hand_to_hand","missiles","armour"])
+
+function transformHiredSwords(source) {
+  const result  = { hiredSwords: [] };
+  const added   = [];
+
+  for (const [key, src] of Object.entries(source)) {
+    const type         = key.replace(/-/g, '_');
+    const stats        = mapStatKeys(src.statblock);
+    const specialRules = (src.specialRules || []).map(r => r.rulename).filter(Boolean);
+    const skillAccess  = Object.entries(src.skillAccess || {})
+      .filter(([k, v]) => v && k !== 'special')
+      .map(([k]) => k);
+
+    const warbandAllowList = [];
+    for (const wbName of (src.permittedWarbands || [])) {
+      const id = HIRED_SWORD_WARBAND_NAME_MAP[wbName];
+      if (id && !warbandAllowList.includes(id)) warbandAllowList.push(id);
+    }
+
+    result.hiredSwords.push({
+      type,
+      name:             src.name,
+      max:              1,
+      cost:             parseInt(src.cost) || 0,
+      stats,
+      specialRules,
+      startingExp:      0,
+      skillAccess,
+      spellAccess:      HIRED_SWORD_SPELL_ACCESS_MAP[key] || [],
+      equipmentAccess:  ['hand_to_hand', 'missiles', 'armour'],
+      warbandAllowList,
+    });
+
+    added.push(type);
+  }
+
+  return { data: result, added };
+}
+```
+
+- [ ] **Step 2: Verify the file still parses**
+
+```bash
+node -e "require('./scripts/sync-mordheim-data.js'); console.log('OK')" 2>&1 | head -5
+```
+
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/sync-mordheim-data.js
+git commit -m "chore: add transformHiredSwords() to sync script"
+```
+
+---
+
+## Task 3: Add `validateHiredSwords()` function
+
+**Files:**
+- Modify: `scripts/sync-mordheim-data.js`
+
+- [ ] **Step 1: Add the validator after `validateSkills()` (before `// ─── Main`)**
+
+```js
+function validateHiredSwords(data) {
+  if (!Array.isArray(data.hiredSwords)) throw new Error('Missing hiredSwords array');
+  if (data.hiredSwords.length === 0)    throw new Error('hiredSwords array is empty');
+  for (const hs of data.hiredSwords) {
+    if (!hs.type)  throw new Error(`Hired sword missing type`);
+    if (!hs.name)  throw new Error(`Hired sword ${hs.type} missing name`);
+    if (!hs.stats) throw new Error(`Hired sword ${hs.type} missing stats`);
+    for (const key of REQUIRED_STAT_KEYS) {
+      if (hs.stats[key] == null) {
+        throw new Error(`Hired sword ${hs.type} missing stat ${key}`);
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Verify the file still parses**
+
+```bash
+node -e "require('./scripts/sync-mordheim-data.js'); console.log('OK')" 2>&1 | head -5
+```
+
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/sync-mordheim-data.js
+git commit -m "chore: add validateHiredSwords() to sync script"
+```
+
+---
+
+## Task 4: Wire up hired swords processing in `main()`
+
+**Files:**
+- Modify: `scripts/sync-mordheim-data.js`
+
+- [ ] **Step 1: Add the processing block in `main()`**
+
+Find the warbands processing block (around line 678). Add the following **after** the warbands block and **before** `// ── Abort on errors`:
+
+```js
+  // Hired Swords
+  if (changes.hiredSwords) {
+    const label = 'hiredSwords';
+    try {
+      process.stdout.write('  hiredSwords... ');
+      const src = ghRaw('data/hiredSwords.json');
+      const { data, added } = transformHiredSwords(src);
+      validateHiredSwords(data);
+      if (!dryRun) writeJson(path.join(DATA_DIR, 'hired_swords.json'), data);
+      summary.added[label]   = added;
+      summary.updated[label] = [];
+      console.log(`total: ${data.hiredSwords.length} ✓`);
+    } catch (err) {
+      summary.errors.push(`HiredSwords: ${err.message}`);
+      console.log(`FAILED: ${err.message}`);
+    }
+  }
+```
+
+- [ ] **Step 2: Verify the file still parses**
+
+```bash
+node -e "require('./scripts/sync-mordheim-data.js'); console.log('OK')" 2>&1 | head -5
+```
+
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/sync-mordheim-data.js
+git commit -m "chore: wire hired swords into sync main()"
+```
+
+---
+
+## Task 5: Dry-run, spot-check output, run live sync
+
+**Files:**
+- Replace: `data/hired_swords.json`
+
+- [ ] **Step 1: Run dry-run**
+
+```bash
+node scripts/sync-mordheim-data.js --dry-run --force 2>&1
+```
+
+Expected: line containing `hiredSwords... total: 72 ✓` and no `FAILED` lines.
+
+- [ ] **Step 2: Preview the transform output for key entries**
+
+```bash
+node -e "
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+// Fetch Uncle-Mel data
+const raw = JSON.parse(execSync('gh api \"repos/Uncle-Mel/JSON-derulo/contents/data/hiredSwords.json\"', {encoding:'utf8'}));
+const src = JSON.parse(Buffer.from(raw.content, 'base64').toString('utf8'));
+
+// Spot-check warlock
+const w = src['warlock'];
+console.log('warlock skillAccess:', Object.entries(w.skillAccess||{}).filter(([,v])=>v&&'special'!==true).map(([k])=>k));
+console.log('warlock stats:', w.statblock);
+
+// Spot-check troll slayer permittedWarbands
+const ts = src['dwarf-troll-slayer'];
+console.log('troll slayer permittedWarbands:', ts.permittedWarbands);
+console.log('troll slayer statblock:', ts.statblock);
+" 2>&1
+```
+
+Expected for warlock:
+- `skillAccess: ['academic', 'speed']`
+- stats present (M/WS/BS/S/T/W/I/A/Ld all lowercase)
+
+Expected for troll slayer:
+- `permittedWarbands` includes Averlanders, Reiklanders, etc.
+- `statblock: { m: 3, ws: 4, bs: 3, s: 3, t: 4, w: 1, i: 2, a: 1, ld: 9 }`
+
+- [ ] **Step 3: Run the live sync**
+
+```bash
+node scripts/sync-mordheim-data.js --force 2>&1
+```
+
+Expected: completes without errors, writes `data/hired_swords.json`, commits, and pushes.
+
+- [ ] **Step 4: Verify the output file**
+
+```bash
+node -e "
+const d = JSON.parse(require('fs').readFileSync('data/hired_swords.json','utf8'));
+console.log('Total hired swords:', d.hiredSwords.length);
+
+const warlock = d.hiredSwords.find(h => h.type === 'warlock');
+console.log('warlock spellAccess:', warlock?.spellAccess);
+console.log('warlock equipmentAccess:', warlock?.equipmentAccess);
+console.log('warlock skillAccess:', warlock?.skillAccess);
+
+const troll = d.hiredSwords.find(h => h.type === 'dwarf_troll_slayer');
+console.log('troll stats:', troll?.stats);
+console.log('troll warbandAllowList length:', troll?.warbandAllowList?.length);
+
+const priest = d.hiredSwords.find(h => h.type === 'priest_of_morr');
+console.log('priest spellAccess:', priest?.spellAccess);
+"
+```
+
+Expected:
+- Total: 72
+- warlock: `spellAccess: ['lesser-magic']`, `equipmentAccess: ['hand_to_hand','missiles','armour']`, `skillAccess: ['academic','speed']`
+- troll stats: `{ M: 3, WS: 4, BS: 3, S: 3, T: 4, W: 1, I: 2, A: 1, Ld: 9 }`, warbandAllowList.length > 5
+- priest: `spellAccess: ['funerary-rites']`
+
+- [ ] **Step 5: Validate JSON**
+
+```bash
+node -e "JSON.parse(require('fs').readFileSync('data/hired_swords.json','utf8')); console.log('OK')"
+```
+
+Expected: `OK`
+
+---
+
+## Task 6: Cache-bust and browser test
+
+**Files:**
+- Modify: `js/data.js` (version bump)
+- Modify: `index.html` (version bump on data.js script tag)
+
+- [ ] **Step 1: Increment version in `js/data.js` line 51**
+
+```js
+// Before:
+const v = 'v=10';
+// After:
+const v = 'v=11';
+```
+
+- [ ] **Step 2: Find the data.js script tag in `index.html` and increment its `?v=N`**
+
+Search for `data.js?v=` in `index.html` and increment the number by 1.
+
+- [ ] **Step 3: Start local server and test**
+
+```bash
+python3 -m http.server 8000
+```
+
+Open http://localhost:8000. For a Reikland warband:
+1. Click "Hire a Sword" — the Dwarf Troll Slayer should now appear (it wasn't in the old 12-entry file)
+2. Open a Warlock's spell modal — it should still show the Lesser Magic list
+3. Open a Warrior-Priest of Sigmar's spell modal — should show Prayers of Sigmar
+
+For an Undead warband: verify that the Dwarf Troll Slayer does NOT appear (warbandAllowList filtering works).
+
+- [ ] **Step 4: Commit the cache bust**
+
+```bash
+git add js/data.js index.html
+git commit -m "chore: bump cache version after hired swords migration to Uncle-Mel sync"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- ✅ Add `hiredSwords.json` to `TRACKED_FILES` — Task 1
+- ✅ Write `transformHiredSwords()` mapping Uncle-Mel fields to our shape — Task 2
+- ✅ `DataService.loadAll()` unchanged — already reads our format
+- ✅ `data/hired_swords.json` is now sync-generated, not hand-maintained — Task 5
+
+**Non-obvious decisions:**
+- `equipmentAccess` always defaults to all three categories. Uncle-Mel has no category data. The old hand-maintained file had per-entry tuning (e.g. Warlock: only `hand_to_hand`), but this is dropped in favour of full alignment with Uncle-Mel. The actual selectable items in the modal are still constrained by what the warband's equipment list contains.
+- `spellAccess` is driven by a static map (`HIRED_SWORD_SPELL_ACCESS_MAP`) in the sync script rather than auto-derived, because Uncle-Mel's magic.json has no hired sword entries. The map covers all 8 casters; `dark-mage` gets `[]` because its "Dark Magic list" has no match in magic.json (the `UI.hasSpellAccess()` fallback detects them via the "Wizard" special rule).
+- Unknown `permittedWarbands` names are silently dropped from `warbandAllowList`. This is acceptable — unmapped warbands are typically those not yet in our app. Add entries to `HIRED_SWORD_WARBAND_NAME_MAP` as new warbands are added.

--- a/index.html
+++ b/index.html
@@ -414,7 +414,7 @@
   <!-- ===== SCRIPTS ===== -->
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="js/cloud.js?v=9"></script>
-  <script src="js/data.js?v=10"></script>
+  <script src="js/data.js?v=11"></script>
   <script src="js/storage.js?v=6"></script>
   <script src="js/roster.js?v=6"></script>
   <script src="js/ui.js?v=19"></script>

--- a/js/data.js
+++ b/js/data.js
@@ -48,7 +48,7 @@ const DataService = {
   },
 
   async loadAll() {
-    const v = 'v=10';
+    const v = 'v=11';
     const [warbands, equipment, skills, injuries, advancement, magic, hiredSwords, specialRules] = await Promise.all([
       this.fetchJSON('data/warbands.json?' + v),
       this.fetchJSON('data/mergedEquipment.json?' + v),

--- a/js/ui.js
+++ b/js/ui.js
@@ -390,7 +390,7 @@ const UI = {
 
     // Hired Swords add dropdown
     const hiredSwordsAddContainer = document.getElementById('hired-swords-add-buttons');
-    const availableHiredSwords = DataService.getAvailableHiredSwords(r.warbandId);
+    const availableHiredSwords = DataService.getAvailableHiredSwords(r.warbandId).sort((a, b) => a.name.localeCompare(b.name));
     hiredSwordsAddContainer.innerHTML = `
       <select id="hired-swords-add-select" class="form-control" style="font-size:0.8rem; padding:0.2rem 2rem 0.2rem 0.4rem;" onclick="event.stopPropagation()" onchange="UI.addWarriorFromSelect('hiredSwords')">
         <option value="">+ Hire Sword</option>

--- a/scripts/sync-mordheim-data.js
+++ b/scripts/sync-mordheim-data.js
@@ -30,9 +30,10 @@ const REQUIRED_STAT_KEYS = ['M', 'WS', 'BS', 'S', 'T', 'W', 'I', 'A', 'Ld'];
 
 // Files to track for change detection (path in source repo → internal key)
 const TRACKED_FILES = [
-  { key: 'equipment', path: 'data/mergedEquipment.json' },
-  { key: 'skills',    path: 'data/skills.json'          },
-  { key: 'magic',     path: 'data/magic.json'           },
+  { key: 'equipment',   path: 'data/mergedEquipment.json' },
+  { key: 'skills',      path: 'data/skills.json'          },
+  { key: 'magic',       path: 'data/magic.json'           },
+  { key: 'hiredSwords', path: 'data/hiredSwords.json'     },
 ];
 const WARBAND_FOLDER = 'data/warbandFiles';
 
@@ -136,6 +137,83 @@ const WARBAND_SPECIAL_SKILL_CATEGORIES = {
   'skaven-of-clan-pestilens': ['clan_pestilens_special'],
   'bretonnians':              ['bretonnian_special'],
   'horned-hunters':           ['horned_hunter_special'],
+};
+
+// Maps Uncle-Mel permittedWarbands display names → our warband IDs (data/warbands.json)
+const HIRED_SWORD_WARBAND_NAME_MAP = {
+  'Arabian Tomb Raiders':             'arabian-tomb-raiders',
+  'Averlanders':                      'averlander-mercenaries',
+  'Battle Monks of Cathay':           'battle-monks-of-cathay',
+  'Beastmen Raiders':                 'beastmen-raiders',
+  'Black Dwarfs':                     'black-dwarfs',
+  'Black Orcs':                       'black-orcs',
+  'Bretonnian Chapel Guard':          'bretonnian-chapel-guard',
+  'Bretonnian Knights':               'bretonnians',
+  'Carnival of Chaos':                'carnival-of-chaos',
+  'Cult of the Possessed':            'cult-of-the-possessed',
+  'Dark Elves':                       'dark-elves',
+  'Dreamwalkers, Cult Of Morr':       'the-restless-dead',
+  'Druchii':                          'dark-elves',
+  'Dwarf Rangers':                    'dwarf-rangers',
+  'Dwarf Slayer Cult':                'dwarf-treasure-hunters',
+  'Dwarf Treasure Hunters':           'dwarf-treasure-hunters',
+  'Forest Goblins':                   'forest-goblins',
+  'Grave Robbers':                    'arabian-tomb-raiders',
+  'Gunnery School of Nuln':           'gunnery-school-of-nuln',
+  'Hochland Bandits':                 'hochland-bandits',
+  'Horned Hunters':                   'horned-hunters',
+  'Imperial Outriders':               'imperial-outriders',
+  'Kislevites':                       'kislevites',
+  'Lizardmen':                        'lizardmen',
+  'Lustrian Reavers':                 'lustrian-reavers',
+  'Maneaters':                        'maneaters',
+  'Marauders of Chaos':               'the_kurgan',
+  'Marienburgers':                    'marienburg_mercenaries',
+  'Merchant Caravans':                'merchant-caravans',
+  'Middenheimers':                    'middenheim_mercenaries',
+  'Miragleans':                       'miragleans',
+  'Mootlanders':                      'mootlanders',
+  'Night Goblins':                    'night-goblins',
+  'Night Goblins (web)':              'night-goblins',
+  'Nipponese Expedition':             'battle-monks-of-cathay',
+  'Norse Explorers':                  'norse-explorers',
+  'Orc Mob':                          'orc-mob',
+  'Ostermarkers':                     'ostlander-mercenaries',
+  'Ostlanders':                       'ostlander-mercenaries',
+  'Outlaws of Stirwood Forest, The':  'outlaws-of-stirwood-forest',
+  'Pirates':                          'pirates',
+  'Pit Fighters':                     'pit-fighters',
+  'Reiklanders':                      'reikland_mercenaries',
+  'Remasens':                         'remasens',
+  'Shadow Warriors':                  'shadow-warriors',
+  'Sisters of Sigmar':                'sisters-of-sigmar',
+  'Skaven':                           'skaven-of-clan-eshin',
+  'Skaven of Clan Pestilens':         'skaven-of-clan-pestilens',
+  'Sons of Hashut:':                  'the-sons-of-hashut',
+  'The Restless Dead':                'the-restless-dead',
+  'The Sons of Hashut':               'the-sons-of-hashut',
+  'Tileans':                          'trantios',
+  'Tomb Guardians':                   'tomb-guardians',
+  'Trantios':                         'trantios',
+  'Undead':                           'undead',
+  'Witch Hunters':                    'witch-hunters',
+  'Mazzalupo':                        'miragleans',
+};
+
+// Maps hired sword entry key → spell list IDs
+// Derived from Uncle-Mel skillText links and specialRules.
+// Only entries with at least one spell list are included; all others default to [].
+const HIRED_SWORD_SPELL_ACCESS_MAP = {
+  'warlock':                  ['lesser-magic'],
+  'elf-mage':                 ['spells-of-the-djedhi'],
+  'norse-shaman':             ['norse-runes'],
+  'warrior-priest-of-sigmar': ['prayers-of-sigmar'],
+  'witch':                    ['charms-and-hexes'],
+  'fallen-sister':            ['lesser-magic'],
+  'priest-of-morr':           ['funerary-rites'],
+  'wolf-priest-of-ulric':     ['prayers-of-ulric'],
+  // dark-mage uses "Dark Magic list" which has no matching entry in magic.json;
+  // the UI hasSpellAccess() fallback detects them via the "Wizard" special rule.
 };
 
 // ─── Skills transformer ───────────────────────────────────────────────────

--- a/scripts/sync-mordheim-data.js
+++ b/scripts/sync-mordheim-data.js
@@ -683,6 +683,21 @@ function validateSkills(data) {
   }
 }
 
+function validateHiredSwords(data) {
+  if (!Array.isArray(data.hiredSwords)) throw new Error('Missing hiredSwords array');
+  if (data.hiredSwords.length === 0)    throw new Error('hiredSwords array is empty');
+  for (const hs of data.hiredSwords) {
+    if (!hs.type)  throw new Error(`Hired sword missing type`);
+    if (!hs.name)  throw new Error(`Hired sword ${hs.type} missing name`);
+    if (!hs.stats) throw new Error(`Hired sword ${hs.type} missing stats`);
+    for (const key of REQUIRED_STAT_KEYS) {
+      if (hs.stats[key] == null) {
+        throw new Error(`Hired sword ${hs.type} missing stat ${key}`);
+      }
+    }
+  }
+}
+
 // ─── Main ─────────────────────────────────────────────────────────────────
 
 async function main() {

--- a/scripts/sync-mordheim-data.js
+++ b/scripts/sync-mordheim-data.js
@@ -587,6 +587,59 @@ function transformWarbands(warbandFiles, existing, magicData, equipmentLookup) {
   return { data: result, added, updated };
 }
 
+// ─── Hired Swords transformer ─────────────────────────────────────────────
+//
+// Source: hiredSwords.json — keyed object { "dwarf-troll-slayer": { ... } }
+// Ours:   hired_swords.json — { hiredSwords: [] }
+//
+// Key field mappings:
+//   key                       → type (hyphens → underscores)
+//   cost                      → cost (parseInt)
+//   statblock (lowercase)     → stats (uppercase via mapStatKeys)
+//   specialRules[].rulename   → specialRules (flat string array)
+//   skillAccess { k: bool }   → skillAccess (truthy keys, excluding "special")
+//   permittedWarbands[]       → warbandAllowList (via HIRED_SWORD_WARBAND_NAME_MAP)
+//   (absent)                  → spellAccess (via HIRED_SWORD_SPELL_ACCESS_MAP; default [])
+//   (absent)                  → equipmentAccess (always ["hand_to_hand","missiles","armour"])
+
+function transformHiredSwords(source) {
+  const result  = { hiredSwords: [] };
+  const added   = [];
+
+  for (const [key, src] of Object.entries(source)) {
+    const type         = key.replace(/-/g, '_');
+    const stats        = mapStatKeys(src.statblock);
+    const specialRules = (src.specialRules || []).map(r => r.rulename).filter(Boolean);
+    const skillAccess  = Object.entries(src.skillAccess || {})
+      .filter(([k, v]) => v && k !== 'special')
+      .map(([k]) => k);
+
+    const warbandAllowList = [];
+    for (const wbName of (src.permittedWarbands || [])) {
+      const id = HIRED_SWORD_WARBAND_NAME_MAP[wbName];
+      if (id && !warbandAllowList.includes(id)) warbandAllowList.push(id);
+    }
+
+    result.hiredSwords.push({
+      type,
+      name:             src.name,
+      max:              1,
+      cost:             parseInt(src.cost) || 0,
+      stats,
+      specialRules,
+      startingExp:      0,
+      skillAccess,
+      spellAccess:      HIRED_SWORD_SPELL_ACCESS_MAP[key] || [],
+      equipmentAccess:  ['hand_to_hand', 'missiles', 'armour'],
+      warbandAllowList,
+    });
+
+    added.push(type);
+  }
+
+  return { data: result, added };
+}
+
 // ─── Validators ───────────────────────────────────────────────────────────
 
 function validateWarbands(data) {

--- a/scripts/sync-mordheim-data.js
+++ b/scripts/sync-mordheim-data.js
@@ -611,7 +611,7 @@ function transformHiredSwords(source) {
     const stats        = mapStatKeys(src.statblock);
     const specialRules = (src.specialRules || []).map(r => r.rulename).filter(Boolean);
     const skillAccess  = Object.entries(src.skillAccess || {})
-      .filter(([k, v]) => v && k !== 'special')
+      .filter(([k, v]) => v && k !== 'special')  // hired swords have no warband-specific special skill categories
       .map(([k]) => k);
 
     const warbandAllowList = [];
@@ -624,7 +624,7 @@ function transformHiredSwords(source) {
       type,
       name:             src.name,
       max:              1,
-      cost:             parseInt(src.cost) || 0,
+      cost:             parseInt(src.cost) || 0,  // parseInt handles numeric-or-range strings; floor value is intentional
       stats,
       specialRules,
       startingExp:      0,

--- a/scripts/sync-mordheim-data.js
+++ b/scripts/sync-mordheim-data.js
@@ -141,6 +141,8 @@ const WARBAND_SPECIAL_SKILL_CATEGORIES = {
 
 // Maps Uncle-Mel permittedWarbands display names → our warband IDs (data/warbands.json)
 const HIRED_SWORD_WARBAND_NAME_MAP = {
+  // Note: some warband IDs use underscores (grade 1c subfactions) rather than hyphens.
+  // This matches data/warbands.json exactly — do not normalise.
   'Arabian Tomb Raiders':             'arabian-tomb-raiders',
   'Averlanders':                      'averlander-mercenaries',
   'Battle Monks of Cathay':           'battle-monks-of-cathay',
@@ -169,6 +171,7 @@ const HIRED_SWORD_WARBAND_NAME_MAP = {
   'Maneaters':                        'maneaters',
   'Marauders of Chaos':               'the_kurgan',
   'Marienburgers':                    'marienburg_mercenaries',
+  'Mazzalupo':                        'miragleans',
   'Merchant Caravans':                'merchant-caravans',
   'Middenheimers':                    'middenheim_mercenaries',
   'Miragleans':                       'miragleans',
@@ -189,7 +192,7 @@ const HIRED_SWORD_WARBAND_NAME_MAP = {
   'Sisters of Sigmar':                'sisters-of-sigmar',
   'Skaven':                           'skaven-of-clan-eshin',
   'Skaven of Clan Pestilens':         'skaven-of-clan-pestilens',
-  'Sons of Hashut:':                  'the-sons-of-hashut',
+  'Sons of Hashut:':                  'the-sons-of-hashut',  // upstream typo — colon is intentional
   'The Restless Dead':                'the-restless-dead',
   'The Sons of Hashut':               'the-sons-of-hashut',
   'Tileans':                          'trantios',
@@ -197,7 +200,6 @@ const HIRED_SWORD_WARBAND_NAME_MAP = {
   'Trantios':                         'trantios',
   'Undead':                           'undead',
   'Witch Hunters':                    'witch-hunters',
-  'Mazzalupo':                        'miragleans',
 };
 
 // Maps hired sword entry key → spell list IDs

--- a/scripts/sync-mordheim-data.js
+++ b/scripts/sync-mordheim-data.js
@@ -867,6 +867,24 @@ async function main() {
     }
   }
 
+  // Hired Swords
+  if (changes.hiredSwords) {
+    const label = 'hiredSwords';
+    try {
+      process.stdout.write('  hiredSwords... ');
+      const src = ghRaw('data/hiredSwords.json');
+      const { data, added } = transformHiredSwords(src);
+      validateHiredSwords(data);
+      if (!dryRun) writeJson(path.join(DATA_DIR, 'hired_swords.json'), data);
+      summary.added[label]   = added;
+      summary.updated[label] = [];
+      console.log(`total: ${data.hiredSwords.length} ✓`);
+    } catch (err) {
+      summary.errors.push(`HiredSwords: ${err.message}`);
+      console.log(`FAILED: ${err.message}`);
+    }
+  }
+
   // ── Abort on errors (before committing) ─────────────────────────────────
   if (summary.errors.length > 0) {
     console.error('\n❌  Validation errors — aborting (no files committed):\n');


### PR DESCRIPTION
Closes #60

## Summary

- Added `hiredSwords.json` to `TRACKED_FILES` in `sync-mordheim-data.js` so Uncle-Mel's data is synced nightly
- Added `transformHiredSwords()` to convert Uncle-Mel's keyed object format to our `{ hiredSwords: [] }` array shape, mapping stats, skill access, spell access, warband allow-list, and equipment access
- Added `validateHiredSwords()` to catch malformed entries before writing
- `data/hired_swords.json` is now sync-generated — 72 entries (up from 12 hand-maintained)

## Notable changes

- **Warband filtering** now uses `warbandAllowList` (Uncle-Mel's allow-list) instead of `warbandRestrictions` (our old deny-list). `DataService.getAvailableHiredSwords()` already supported this.
- **`hired_swordsman` type removed** — Uncle-Mel doesn't carry this entry. Existing rosters with a Hired Swordsman will still render the warrior card (name/stats stored on the object) but equipment and skill modals will show empty categories.
- **Warlock `skillAccess`** is now `['academic']` only — Uncle-Mel's upstream data does not include `speed`. Previous hand-maintained file had `['academic', 'speed']`. May be worth flagging upstream in JSON-derulo.
- **`dark_mage` has no `spellAccess`** — "Dark Magic list" has no matching entry in `magic.json`. The `UI.hasSpellAccess()` fallback detects them via the `Wizard` special rule so the spell button still shows; the modal will say no lists available.

## Test plan

- [ ] Open any eligible warband (e.g. Reikland) and click Hire a Sword — Dwarf Troll Slayer and other new entries should now appear
- [ ] Confirm Undead warband cannot hire the Dwarf Troll Slayer (warband filtering)
- [ ] Open a Warlock's spell modal — Lesser Magic list should appear
- [ ] Open a Warrior-Priest of Sigmar's spell modal — Prayers of Sigmar should appear
- [ ] Open a Priest of Morr's spell modal — Funerary Rites should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)