### PR TITLE
fix: warband-specific Special Skills not showing in skill picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -481,7 +481,7 @@
   <!-- ===== SCRIPTS ===== -->
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="js/cloud.js?v=10"></script>
-  <script src="js/data.js?v=13"></script>
+  <script src="js/data.js?v=14"></script>
   <script src="js/storage.js?v=8"></script>
   <script src="js/roster.js?v=8"></script>
   <script src="js/ui.js?v=28"></script>

--- a/js/data.js
+++ b/js/data.js
@@ -246,11 +246,13 @@ const DataService = {
   // For 'Special Skill', optionally filters by permittedWarbands.
   getSkillsBySubtype(subtype, warbandName) {
     if (subtype === 'Special Skill' && warbandName) {
-      return this.skills.filter(s =>
-        s.subtype === 'Special Skill' &&
-        Array.isArray(s.permittedWarbands) &&
-        s.permittedWarbands.includes(warbandName)
-      );
+      return this.skills.filter(s => {
+        if (s.subtype !== 'Special Skill') return false;
+        const p = s.permittedWarbands;
+        if (Array.isArray(p)) return p.includes(warbandName);
+        if (typeof p === 'string') return p === warbandName;
+        return false;
+      });
     }
     return this.skills.filter(s => s.subtype === subtype);
   },


### PR DESCRIPTION
## Summary
- 182 of 202 warband-specific Special Skills in `skills.json` store `permittedWarbands` as a plain string (e.g. `"The Restless Dead"`) rather than an array
- `getSkillsBySubtype()` required `Array.isArray()` so all string-keyed skills were silently excluded — Corpse Bomb, Shaggy Hide, Bellowing Roar, and most other warband specials were invisible in the skill picker
- Fix now handles both string and array shapes

## Test plan
- [ ] Open skill modal for a Restless Dead Necromancer or Liche — Corpse Bomb and other Special Skills appear
- [ ] Open skill modal for a Beastmen Raiders hero — warband-specific specials (Shaggy Hide, Mutant, etc.) appear
- [ ] Standard skills (Combat, Speed, etc.) still show correctly for all warriors

🤖 Generated with [Claude Code](https://claude.com/claude-code)