### PR TITLE
feat: predefined starting GC when creating a warband

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,6 +312,10 @@
             <option value="">-- Select Warband --</option>
           </select>
         </div>
+        <div class="form-group">
+          <label for="create-starting-gold">Starting Gold (gc)</label>
+          <input type="number" id="create-starting-gold" class="form-control" min="0" value="500">
+        </div>
         <p id="warband-description" class="text-dim" style="font-size:0.85rem; min-height:2rem;"></p>
       </div>
       <div class="modal-footer">
@@ -484,7 +488,7 @@
   <script src="js/data.js?v=13"></script>
   <script src="js/storage.js?v=8"></script>
   <script src="js/roster.js?v=8"></script>
-  <script src="js/ui.js?v=28"></script>
+  <script src="js/ui.js?v=29"></script>
   <script>
     // Boot the app
     (async function() {

--- a/js/ui.js
+++ b/js/ui.js
@@ -263,6 +263,7 @@ const UI = {
         .map(w => `<option value="${w.id}">${this.esc(w.name)} (${this.esc(w.source)})</option>`)
         .join('');
     document.getElementById('create-roster-name').value = '';
+    document.getElementById('create-starting-gold').value = '500';
     document.getElementById('warband-description').textContent = '';
     modal.classList.add('active');
   },
@@ -274,13 +275,17 @@ const UI = {
   onWarbandSelectChange() {
     const id = document.getElementById('create-warband-select').value;
     const desc = document.getElementById('warband-description');
+    const goldInput = document.getElementById('create-starting-gold');
     const result = DataService.getWarband(id);
     if (result) {
       const { warbandFile } = result;
+      const startingGc = parseInt(warbandFile.warbandRules?.startingGc, 10) || 500;
+      if (goldInput) goldInput.value = startingGc;
       const lore = DataService._stripHtml(warbandFile.lore || warbandFile.warbandRules?.choiceFluff || '')
         .replace(/\s+/g, ' ').trim().slice(0, 300);
-      desc.textContent = `${lore} Starting gold: ${warbandFile.warbandRules?.startingGc ?? 500} gc.`;
+      desc.textContent = lore;
     } else {
+      if (goldInput) goldInput.value = '500';
       desc.textContent = '';
     }
   },
@@ -292,6 +297,12 @@ const UI = {
     if (!warbandId) return this.toast('Select a warband type.', 'error');
 
     const roster = RosterModel.createRoster(name, warbandId);
+    const goldInput = document.getElementById('create-starting-gold');
+    const startingGold = goldInput ? parseInt(goldInput.value, 10) : NaN;
+    if (isNaN(startingGold) || startingGold < 0) {
+      return this.toast('Enter a valid starting gold amount (0 or greater).', 'error');
+    }
+    roster.gold = startingGold;
     Storage.saveRoster(roster);
     this.closeCreateModal();
     this.renderRosterList();


### PR DESCRIPTION
Closes #73

## Summary
- Adds a **Starting Gold (gc)** number input to the Create Warband modal
- Selecting a warband auto-fills the field from `warbandRules.startingGc` (defaults to 500)
- User can freely adjust before creating — validated on submit (must be ≥ 0)
- `roster.gold` is set to the entered value instead of the warband default

## Test plan
- [ ] Open Create Warband modal — Starting Gold field shows 500
- [ ] Select a warband — field updates to that warband's default GC
- [ ] Change the value to 250 and create — Progress tab shows 250 gc
- [ ] Leave at default and create — gold matches warband's normal starting GC
- [ ] Enter a negative number — error toast, warband not created
- [ ] Cancel and reopen modal — field resets to 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)