### PR TITLE
feat: first Dagger is free per warrior

### DIFF
--- a/index.html
+++ b/index.html
@@ -488,7 +488,7 @@
   <script src="js/data.js?v=14"></script>
   <script src="js/storage.js?v=8"></script>
   <script src="js/roster.js?v=8"></script>
-  <script src="js/ui.js?v=30"></script>
+  <script src="js/ui.js?v=31"></script>
   <script>
     // Boot the app
     (async function() {

--- a/index.html
+++ b/index.html
@@ -488,7 +488,7 @@
   <script src="js/data.js?v=14"></script>
   <script src="js/storage.js?v=8"></script>
   <script src="js/roster.js?v=8"></script>
-  <script src="js/ui.js?v=29"></script>
+  <script src="js/ui.js?v=30"></script>
   <script>
     // Boot the app
     (async function() {

--- a/js/ui.js
+++ b/js/ui.js
@@ -924,7 +924,7 @@ const UI = {
         const catName = DataService.getEquipmentCategoryName(type);
         html += `<optgroup label="${this.escAttr(catName)}">`;
         for (const item of items) {
-          const prefix = item.costPrefix ? `${item.costPrefix}` : '';
+          const prefix = item.costPrefix ? this.esc(item.costPrefix) : '';
           html += `<option value="${this.escAttr(item.id)}">${this.esc(item.name)} (${prefix}${item.cost ?? 0} gc)</option>`;
         }
         html += '</optgroup>';
@@ -984,7 +984,8 @@ const UI = {
   selectEquipment(listType, index, itemId) {
     const warrior = this.currentRoster[listType][index];
     if (!warrior) return;
-    RosterModel.addEquipment(warrior, itemId);
+    const added = RosterModel.addEquipment(warrior, itemId);
+    if (!added) return this.toast('Could not add item: equipment data not found.', 'error');
     const item = DataService.getEquipmentItem(itemId);
     if (item) this._logEquipmentPurchase(item, warrior);
     this.saveCurrentRoster();
@@ -1009,7 +1010,7 @@ const UI = {
       // exactly 1 means this is the first copy.
       if (item.cost?.costPrefix?.includes('1st free') && warrior) {
         const copies = (warrior.equipment || []).filter(e => e.id === item.id).length;
-        if (copies <= 1) cost = 0;
+        if (copies === 1) cost = 0; // exactly 1 = this is the first copy (added before this call)
       }
       const gold = -Math.abs(cost);
       const prevGold = r.gold || 0;
@@ -1030,6 +1031,7 @@ const UI = {
       r.gold = newGold;
     } catch (err) {
       console.error('Treasury log failed for equipment purchase:', err);
+      this.toast('Equipment added, but treasury log failed. Gold balance may be incorrect.', 'error');
     }
   },
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -963,7 +963,9 @@ const UI = {
       const catName = DataService.getEquipmentCategoryName(type);
       html += `<optgroup label="${this.escAttr(catName)}">`;
       for (const item of items) {
-        html += `<option value="${this.escAttr(item.id)}">${this.esc(item.name)} (${item.cost?.cost ?? 0} gc)</option>`;
+        const prefix = item.cost?.costPrefix ? this.esc(item.cost.costPrefix) : '';
+        const costLabel = `${prefix}${item.cost?.cost ?? 0} gc`;
+        html += `<option value="${this.escAttr(item.id)}">${this.esc(item.name)} (${costLabel})</option>`;
       }
       html += '</optgroup>';
     }
@@ -984,7 +986,7 @@ const UI = {
     if (!warrior) return;
     RosterModel.addEquipment(warrior, itemId);
     const item = DataService.getEquipmentItem(itemId);
-    if (item) this._logEquipmentPurchase(item);
+    if (item) this._logEquipmentPurchase(item, warrior);
     this.saveCurrentRoster();
     this.renderRosterEditor();
     document.getElementById('equipment-modal').classList.remove('active');
@@ -994,13 +996,21 @@ const UI = {
   // Appends a 'purchase' treasury log entry for an equipment buy (Pro tier only).
   // Gold is only updated after the entry is pushed so a throw mid-function
   // cannot leave the roster with decremented gold and no log entry.
-  _logEquipmentPurchase(item) {
+  // warrior is passed so we can detect "1st free" items (e.g. the Dagger).
+  _logEquipmentPurchase(item, warrior) {
     if (typeof Cloud === 'undefined' || !Cloud.canAccess('treasury_ledger')) return;
     const r = this.currentRoster;
     if (!r) return;
     try {
       const rawCost = item.cost?.cost;
-      const cost = (typeof rawCost === 'number' && isFinite(rawCost)) ? rawCost : 0;
+      let cost = (typeof rawCost === 'number' && isFinite(rawCost)) ? rawCost : 0;
+      // Items with costPrefix '1st free/' are free for the first copy per warrior.
+      // After addEquipment the item is already in warrior.equipment, so a count of
+      // exactly 1 means this is the first copy.
+      if (item.cost?.costPrefix?.includes('1st free') && warrior) {
+        const copies = (warrior.equipment || []).filter(e => e.id === item.id).length;
+        if (copies <= 1) cost = 0;
+      }
       const gold = -Math.abs(cost);
       const prevGold = r.gold || 0;
       const newGold = Math.max(0, prevGold + gold);


### PR DESCRIPTION
## Summary
- When a warrior's **first Dagger** is added via the equipment picker, the treasury log records it at **0 gc** instead of 2 gc
- Subsequent daggers on the same warrior charge the normal 2 gc
- Driven by the existing `costPrefix: '1st free/'` field already on the Dagger in `equipment.json` — data-driven, no item name hardcoded
- Any future item that also gets `costPrefix: '1st free/'` in the data will automatically get the same treatment
- Equipment picker dropdown now shows the prefix label: **"Dagger (1st free/2 gc)"** so players know the rule before selecting

## Test plan
- [ ] Add a Dagger to a warrior — treasury log shows **0 gc** deducted, treasury balance unchanged
- [ ] Add a second Dagger to the same warrior — treasury log shows **−2 gc** deducted normally
- [ ] A different warrior's first Dagger is also free
- [ ] Equipment picker shows "Dagger (1st free/2 gc)" in the dropdown label
- [ ] Other equipment (Sword, Shield, etc.) still charges normally
- [ ] Non-Pro users: equipment still adds without any logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)