### PR TITLE
feat: XP bar for henchmen (levels at 2/5/9/15 XP)

### DIFF
--- a/data/advancement.json
+++ b/data/advancement.json
@@ -1,4 +1,7 @@
 {
+  "henchmanAdvancement": {
+    "expThresholds": [2, 5, 9, 15]
+  },
   "heroAdvancement": {
     "expThresholds": [2, 4, 6, 8, 11, 14, 17, 20, 24, 28, 32, 36, 41, 46, 51, 57, 63, 69, 76, 83, 90],
     "advanceRoll": {

--- a/index.html
+++ b/index.html
@@ -487,8 +487,8 @@
   <script src="js/cloud.js?v=10"></script>
   <script src="js/data.js?v=14"></script>
   <script src="js/storage.js?v=8"></script>
-  <script src="js/roster.js?v=8"></script>
-  <script src="js/ui.js?v=31"></script>
+  <script src="js/roster.js?v=9"></script>
+  <script src="js/ui.js?v=32"></script>
   <script>
     // Boot the app
     (async function() {

--- a/index.html
+++ b/index.html
@@ -485,10 +485,10 @@
   <!-- ===== SCRIPTS ===== -->
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="js/cloud.js?v=10"></script>
-  <script src="js/data.js?v=14"></script>
+  <script src="js/data.js?v=15"></script>
   <script src="js/storage.js?v=8"></script>
-  <script src="js/roster.js?v=9"></script>
-  <script src="js/ui.js?v=32"></script>
+  <script src="js/roster.js?v=10"></script>
+  <script src="js/ui.js?v=33"></script>
   <script>
     // Boot the app
     (async function() {

--- a/js/data.js
+++ b/js/data.js
@@ -82,7 +82,7 @@ const DataService = {
   },
 
   async loadAll() {
-    const v = 'v=12';
+    const v = 'v=13';
 
     // Fetch warband index first, then all warband files in parallel
     const indexData = await this.fetchJSON('data/warbandFiles/index.json?' + v);

--- a/js/roster.js
+++ b/js/roster.js
@@ -211,7 +211,7 @@ const RosterModel = {
   },
 
   getHenchmanLevel(experience) {
-    const thresholds = DataService.advancement.henchmanAdvancement.expThresholds;
+    const thresholds = DataService.advancement?.henchmanAdvancement?.expThresholds || [2, 5, 9, 15];
     let level = 0;
     for (let i = 0; i < thresholds.length; i++) {
       if (experience >= thresholds[i]) level = i + 1;
@@ -221,7 +221,7 @@ const RosterModel = {
   },
 
   getHenchmanNextThreshold(experience) {
-    const thresholds = DataService.advancement.henchmanAdvancement.expThresholds;
+    const thresholds = DataService.advancement?.henchmanAdvancement?.expThresholds || [2, 5, 9, 15];
     for (const t of thresholds) {
       if (experience < t) return t;
     }

--- a/js/roster.js
+++ b/js/roster.js
@@ -210,6 +210,24 @@ const RosterModel = {
     warrior.experience += amount;
   },
 
+  getHenchmanLevel(experience) {
+    const thresholds = DataService.advancement.henchmanAdvancement.expThresholds;
+    let level = 0;
+    for (let i = 0; i < thresholds.length; i++) {
+      if (experience >= thresholds[i]) level = i + 1;
+      else break;
+    }
+    return level;
+  },
+
+  getHenchmanNextThreshold(experience) {
+    const thresholds = DataService.advancement.henchmanAdvancement.expThresholds;
+    for (const t of thresholds) {
+      if (experience < t) return t;
+    }
+    return null; // max level reached
+  },
+
   getHeroLevel(experience) {
     const thresholds = DataService.advancement.heroAdvancement.expThresholds;
     let level = 0;

--- a/js/ui.js
+++ b/js/ui.js
@@ -475,7 +475,7 @@ const UI = {
     } else {
       const hLevel = RosterModel.getHenchmanLevel(warrior.experience);
       const hNext  = RosterModel.getHenchmanNextThreshold(warrior.experience);
-      const hThresholds = DataService.advancement.henchmanAdvancement.expThresholds;
+      const hThresholds = DataService.advancement?.henchmanAdvancement?.expThresholds || [2, 5, 9, 15];
       const hPrev  = hLevel > 0 ? hThresholds[hLevel - 1] : 0;
       const hProgress = hNext != null
         ? ((warrior.experience - hPrev) / (hNext - hPrev)) * 100

--- a/js/ui.js
+++ b/js/ui.js
@@ -473,9 +473,21 @@ const UI = {
         </div>
       `;
     } else {
+      const hLevel = RosterModel.getHenchmanLevel(warrior.experience);
+      const hNext  = RosterModel.getHenchmanNextThreshold(warrior.experience);
+      const hThresholds = DataService.advancement.henchmanAdvancement.expThresholds;
+      const hPrev  = hLevel > 0 ? hThresholds[hLevel - 1] : 0;
+      const hProgress = hNext != null
+        ? ((warrior.experience - hPrev) / (hNext - hPrev)) * 100
+        : 100; // max level — full bar
+      const hNextLabel = hNext != null ? `Next: ${hNext}` : 'Max level';
       expBar = `
         <div class="exp-bar-container">
-          <div class="exp-bar-label"><span>EXP: ${warrior.experience}</span><span>Group Size: ${warrior.groupSize || 1}</span></div>
+          <div class="exp-bar-label">
+            <span>EXP: ${warrior.experience} (Level ${hLevel})</span>
+            <span>${hNextLabel} &nbsp;·&nbsp; Group: ${warrior.groupSize || 1}</span>
+          </div>
+          <div class="exp-bar"><div class="exp-bar-fill" style="width:${Math.min(hProgress, 100)}%"></div></div>
         </div>
       `;
     }


### PR DESCRIPTION
Closes #71

## Summary
- Henchman warrior cards now show the same XP bar as heroes
- Levels advance at **2, 5, 9, and 15** XP (stored in `advancement.json` under `henchmanAdvancement.expThresholds`)
- Bar fills proportionally within the current level; shows "Max level" at 15+ XP
- Group size stays on the label row: `EXP: 3 (Level 1) · Next: 5 · Group: 2`
- Reuses existing `.exp-bar` / `.exp-bar-fill` CSS — no new styles needed

## Test plan
- [ ] Henchman at 0 XP: Level 0, bar empty, "Next: 2"
- [ ] Henchman at 2 XP: Level 1, bar partially filled, "Next: 5"
- [ ] Henchman at 5 XP: Level 2, "Next: 9"
- [ ] Henchman at 9 XP: Level 3, "Next: 15"
- [ ] Henchman at 15 XP: Level 4, bar full, "Max level"
- [ ] Group size still visible next to XP info
- [ ] Heroes unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)