### PR TITLE
fix: clamp tooltip bottom edge to prevent overflow on long descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -488,7 +488,7 @@
   <script src="js/data.js?v=15"></script>
   <script src="js/storage.js?v=8"></script>
   <script src="js/roster.js?v=10"></script>
-  <script src="js/ui.js?v=34"></script>
+  <script src="js/ui.js?v=35"></script>
   <script>
     // Boot the app
     (async function() {

--- a/index.html
+++ b/index.html
@@ -488,7 +488,7 @@
   <script src="js/data.js?v=15"></script>
   <script src="js/storage.js?v=8"></script>
   <script src="js/roster.js?v=10"></script>
-  <script src="js/ui.js?v=35"></script>
+  <script src="js/ui.js?v=36"></script>
   <script>
     // Boot the app
     (async function() {

--- a/index.html
+++ b/index.html
@@ -488,7 +488,7 @@
   <script src="js/data.js?v=15"></script>
   <script src="js/storage.js?v=8"></script>
   <script src="js/roster.js?v=10"></script>
-  <script src="js/ui.js?v=33"></script>
+  <script src="js/ui.js?v=34"></script>
   <script>
     // Boot the app
     (async function() {

--- a/js/ui.js
+++ b/js/ui.js
@@ -2078,10 +2078,16 @@ const UI = {
       }
       if (left < 8) left = 8;
 
-      // If no room above, show below
+      // Prefer above the tag; fall back to below if not enough room
       if (top < 8) {
         top = rect.bottom + 8;
       }
+
+      // Clamp bottom — handles both above and below placements
+      if (top + ttRect.height > window.innerHeight - 8) {
+        top = window.innerHeight - ttRect.height - 8;
+      }
+      if (top < 8) top = 8; // taller than viewport: pin to top
 
       tooltipEl.style.left = left + 'px';
       tooltipEl.style.top = top + 'px';

--- a/js/ui.js
+++ b/js/ui.js
@@ -541,7 +541,7 @@ const UI = {
               ${warrior.equipment.map((eq, eqIdx) => {
                 const itemData = DataService.getEquipmentItem(eq.id);
                 const tooltip = itemData ? this.escAttr(DataService._stripHtml(itemData.specialRules?.[0]?.ruleAbbreviated || '')) : '';
-                return `<span class="tag equipment" ${tooltip ? `data-tooltip="${tooltip}"` : ''}>${eq.name} <span class="tag-remove" onclick="UI.removeEquipment('${listType}', ${index}, ${eqIdx})">x</span></span>`;
+                return `<span class="tag equipment" ${tooltip ? `data-tooltip="${tooltip}"` : ''}>${this.esc(eq.name)} <span class="tag-remove" onclick="UI.removeEquipment('${listType}', ${index}, ${eqIdx})">x</span></span>`;
               }).join('')}
               <button class="btn btn-sm" onclick="UI.openEquipmentModal('${listType}', ${index})">+ Add</button>
             </div>
@@ -552,8 +552,8 @@ const UI = {
             <div class="tag-list">
               ${warrior.skills.map((sk, skIdx) => {
                 const skillData = DataService.getSkill(sk.id);
-                const tooltip = skillData ? this.esc(DataService._stripHtml(skillData.Rules?.[0]?.ruleAbbreviated || '')) : '';
-                return `<span class="tag skill" ${tooltip ? `data-tooltip="${tooltip}"` : ''}>${sk.name} <span class="tag-remove" onclick="UI.removeSkill('${listType}', ${index}, ${skIdx})">x</span></span>`;
+                const tooltip = skillData ? DataService._stripHtml(skillData.Rules?.[0]?.ruleAbbreviated || '') : '';
+                return `<span class="tag skill" ${tooltip ? `data-tooltip="${this.escAttr(tooltip)}"` : ''}>${this.esc(sk.name)} <span class="tag-remove" onclick="UI.removeSkill('${listType}', ${index}, ${skIdx})">x</span></span>`;
               }).join('')}
               ${isHero ? `<button class="btn btn-sm" onclick="UI.openSkillModal('${listType}', ${index})">+ Add</button>` : ''}
             </div>

--- a/js/ui.js
+++ b/js/ui.js
@@ -609,10 +609,10 @@ const UI = {
       const spellData = DataService.getSpell(sp.id);
       const diff = spellData ? (spellData.difficulty === 'Auto' ? 'Auto' : 'Diff: ' + spellData.difficulty) : '';
       const desc = spellData
-        ? this.esc(DataService._stripHtml(spellData.ruleAbbreviated || spellData.ruleFull || ''))
+        ? DataService._stripHtml(spellData.ruleAbbreviated || spellData.ruleFull || '')
         : '';
       const tooltip = diff && desc ? diff + '. ' + desc : desc;
-      return '<span class="tag spell-tag"' + (tooltip ? ' data-tooltip="' + tooltip + '"' : '') + '>' + sp.name + ' <span class="tag-remove" onclick="UI.removeSpell(\'' + listType + '\', ' + index + ', ' + spIdx + ')">x</span></span>';
+      return '<span class="tag spell-tag"' + (tooltip ? ' data-tooltip="' + this.escAttr(tooltip) + '"' : '') + '>' + this.esc(sp.name) + ' <span class="tag-remove" onclick="UI.removeSpell(\'' + listType + '\', ' + index + ', ' + spIdx + ')">x</span></span>';
     }).join('');
     return '<div class="tag-section mt-1">' +
       '<div class="tag-section-label">Spells</div>' +


### PR DESCRIPTION
## Summary
- Tooltips with long text (e.g. Living Horror spell, Restless Dead) were being cut off at the bottom of the viewport
- The existing logic correctly flipped above→below when near the top of the screen, but never checked if the below-placement also overflowed the bottom
- Added a bottom clamp after the above/below decision, plus a final pin-to-top guard for tooltips taller than the viewport

## Test plan
- [ ] Hover over Living Horror spell tag (Restless Dead warband) — tooltip should be fully visible
- [ ] Hover over tags near the top of the screen — tooltip still flips to below
- [ ] Hover over tags near the bottom of the screen — tooltip clamps instead of overflowing
- [ ] Hover over tags near the right edge — horizontal clamping still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)