### PR TITLE
feat: multiply equipment cost by group size for henchman purchases

### DIFF
--- a/index.html
+++ b/index.html
@@ -488,7 +488,7 @@
   <script src="js/data.js?v=15"></script>
   <script src="js/storage.js?v=8"></script>
   <script src="js/roster.js?v=10"></script>
-  <script src="js/ui.js?v=38"></script>
+  <script src="js/ui.js?v=39"></script>
   <script>
     // Boot the app
     (async function() {

--- a/index.html
+++ b/index.html
@@ -488,7 +488,7 @@
   <script src="js/data.js?v=15"></script>
   <script src="js/storage.js?v=8"></script>
   <script src="js/roster.js?v=10"></script>
-  <script src="js/ui.js?v=37"></script>
+  <script src="js/ui.js?v=38"></script>
   <script>
     // Boot the app
     (async function() {

--- a/index.html
+++ b/index.html
@@ -488,7 +488,7 @@
   <script src="js/data.js?v=15"></script>
   <script src="js/storage.js?v=8"></script>
   <script src="js/roster.js?v=10"></script>
-  <script src="js/ui.js?v=36"></script>
+  <script src="js/ui.js?v=37"></script>
   <script>
     // Boot the app
     (async function() {

--- a/js/ui.js
+++ b/js/ui.js
@@ -1289,8 +1289,65 @@ const UI = {
     const maxSize = fighter?.groupSize?.max || 5;
     if (newSize > maxSize) return this.toast(`Maximum group size is ${maxSize}.`, 'error');
     henchman.groupSize = newSize;
+    if (delta > 0) this._logGroupSizeIncrease(henchman, delta);
     this.saveCurrentRoster();
     this.renderRosterEditor();
+  },
+
+  // Logs treasury entries when models are added to a henchman group.
+  // Always charges full price for equipment — "1st free" was already claimed
+  // when the item was first added to the group.
+  _logGroupSizeIncrease(henchman, addedCount) {
+    if (typeof Cloud === 'undefined' || !Cloud.canAccess('treasury_ledger')) return;
+    const r = this.currentRoster;
+    if (!r) return;
+    try {
+      const entries = [];
+
+      // Model hire cost
+      const modelCost = (typeof henchman.cost === 'number' ? henchman.cost : 0) * addedCount;
+      const modelDesc = addedCount > 1
+        ? `Hired ${henchman.typeName || henchman.name} ×${addedCount}`
+        : `Hired ${henchman.typeName || henchman.name}`;
+      if (modelCost > 0) {
+        entries.push({ desc: modelDesc, cost: modelCost });
+      }
+
+      // Equipment already carried by the group — new models need the same kit
+      for (const eq of (henchman.equipment || [])) {
+        const itemData = DataService.getEquipmentItem(eq.id);
+        if (!itemData) continue;
+        const rawCost = itemData.cost?.cost;
+        const unitCost = (typeof rawCost === 'number' && isFinite(rawCost)) ? rawCost : 0;
+        if (unitCost <= 0) continue;
+        const desc = addedCount > 1
+          ? `${itemData.name || eq.name} ×${addedCount}`
+          : (itemData.name || eq.name);
+        entries.push({ desc, cost: unitCost * addedCount });
+      }
+
+      // Push entries and update gold sequentially so actualGoldDelta is accurate per entry
+      r.treasuryLog = r.treasuryLog || [];
+      let gold = r.gold || 0;
+      for (const e of entries) {
+        const newGold = Math.max(0, gold + (-e.cost));
+        r.treasuryLog.push({
+          id: Storage.generateId(),
+          type: 'purchase',
+          description: e.desc,
+          gold: -e.cost,
+          wyrdstone: 0,
+          applied: true,
+          date: new Date().toISOString(),
+          actualGoldDelta: newGold - gold,
+          actualWyrdstoneDelta: 0,
+        });
+        gold = newGold;
+      }
+      r.gold = gold;
+    } catch (err) {
+      console.error('Treasury log failed for group size increase:', err);
+    }
   },
 
   // === PROGRESS TAB ===

--- a/js/ui.js
+++ b/js/ui.js
@@ -1016,21 +1016,27 @@ const UI = {
     if (!r) return;
     try {
       const rawCost = item.cost?.cost;
-      let cost = (typeof rawCost === 'number' && isFinite(rawCost)) ? rawCost : 0;
+      let unitCost = (typeof rawCost === 'number' && isFinite(rawCost)) ? rawCost : 0;
       // Items with costPrefix '1st free/' are free for the first copy per warrior.
       // After addEquipment the item is already in warrior.equipment, so a count of
       // exactly 1 means this is the first copy.
       if (item.cost?.costPrefix?.includes('1st free') && warrior) {
         const copies = (warrior.equipment || []).filter(e => e.id === item.id).length;
-        if (copies === 1) cost = 0; // exactly 1 = this is the first copy (added before this call)
+        if (copies === 1) unitCost = 0; // exactly 1 = this is the first copy (added before this call)
       }
+      // Henchman groups: multiply by group size — all models in the group are equipped.
+      const groupSize = (!warrior.isHero && warrior.groupSize > 1) ? warrior.groupSize : 1;
+      const cost = unitCost * groupSize;
+      const description = groupSize > 1
+        ? `${item.name || '(unknown)'} ×${groupSize}`
+        : (item.name || '(unknown)');
       const gold = -Math.abs(cost);
       const prevGold = r.gold || 0;
       const newGold = Math.max(0, prevGold + gold);
       const entry = {
         id: Storage.generateId(),
         type: 'purchase',
-        description: item.name || '(unknown)',
+        description,
         gold,
         wyrdstone: 0,
         applied: true,

--- a/js/ui.js
+++ b/js/ui.js
@@ -1314,11 +1314,18 @@ const UI = {
       }
 
       // Equipment already carried by the group — new models need the same kit
+      // Track how many times each item id appears so we can apply "1st free"
+      // to the first copy — each new model gets their own first dagger free.
+      const copyCount = new Map();
       for (const eq of (henchman.equipment || [])) {
         const itemData = DataService.getEquipmentItem(eq.id);
         if (!itemData) continue;
         const rawCost = itemData.cost?.cost;
-        const unitCost = (typeof rawCost === 'number' && isFinite(rawCost)) ? rawCost : 0;
+        let unitCost = (typeof rawCost === 'number' && isFinite(rawCost)) ? rawCost : 0;
+        const copyNum = (copyCount.get(eq.id) || 0) + 1;
+        copyCount.set(eq.id, copyNum);
+        // 1st free per model: the first copy of a "1st free" item is free for each new model
+        if (itemData.cost?.costPrefix?.includes('1st free') && copyNum === 1) unitCost = 0;
         if (unitCost <= 0) continue;
         const desc = addedCount > 1
           ? `${itemData.name || eq.name} ×${addedCount}`


### PR DESCRIPTION
## Summary
- Henchman groups now correctly charge `unitCost × groupSize` when buying equipment
- Treasury description shows the multiplier: e.g. `Spear ×3`
- 1st-free items (Dagger) still work correctly: `0 × groupSize = 0gc`
- Heroes unaffected (groupSize guard: `!warrior.isHero && groupSize > 1`)

## Test plan
- [ ] Henchman group of 3, buy Spear (10gc) → 30gc deducted, log shows "Spear ×3"
- [ ] Henchman group of 1, buy Spear → 10gc deducted, log shows "Spear" (no ×1)
- [ ] Hero buys Spear → 10gc deducted, log shows "Spear"
- [ ] Henchman group of 3, buy first Dagger (1st free) → 0gc deducted
- [ ] Henchman group of 3, buy second Dagger → 30gc deducted, log shows "Dagger ×3"

🤖 Generated with [Claude Code](https://claude.com/claude-code)