### PR TITLE
feat: design system overhaul — OKLCH colors, Pirata One + Alegreya, remove AI patterns

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,45 @@
+# Impeccable Design Context
+
+## Design Context
+
+### Users
+Mordheim tabletop wargamers — hobbyists who care deeply about the game's lore, aesthetics, and campaign narrative. They use this tool at the table or after a session to track their warband's progress. Most use dark mode. The audience is the gaming community broadly: from casual players who found the app online to dedicated campaign veterans. They know what Mordheim is, they're invested in it, and they'll notice if the tool feels generic.
+
+**Job to be done**: Manage warriors, track injuries and experience, equip warbands, record campaign history — without fighting the interface.
+
+**Emotional goal**: The app should feel like pulling out a battered campaign ledger. It should have weight and character. Using it is part of the ritual, not an overhead tax on playing.
+
+### Brand Personality
+**Three words: grim, archival, deliberate**
+
+Not baroque. Not decorated. An archivist's record book found in a ruined Mordheim warehouse — precise, purposeful marks, but carrying the atmosphere of the world it documents. Every element earns its place like an entry in a carefully kept ledger.
+
+### Aesthetic Direction
+- **Primary theme**: Dark. Rich, warm dark — candlelit, not sterile black
+- **Tone**: Modern minimalism with medieval DNA. Think museum catalog for dark artifacts. Clean grid, careful whitespace — but the typography and color carry weight
+- **Anti-references**: Generic D&D app, Excel spreadsheet, Warhammer 40K sci-fi darkness, glowing-rune fantasy UI, corporate dashboard with a skull slapped on it
+- **References to feel**: A well-designed historical archive. A hand-typeset broadsheet. A careful ledger of dangerous deeds
+- **Accent**: Warm amber/tallow-candle gold — aged, not bright
+- **Texture**: Subtle noise and grain, not slathered parchment — the texture should be felt, not seen
+
+### Typography
+- **Display**: Pirata One — Gothic script character, legible, has a cut dangerous quality that fits Mordheim's ruined pirate-city aesthetic without being unreadable blackletter
+- **Body/UI**: Alegreya — humanist serif designed for reading, ink-trap charm, editorial quality. Not a default reflex font.
+- **Labels/tags**: Alegreya SC (small caps variant) or Cinzel for short uppercase labels only
+
+### Color
+OKLCH-based, dark mode primary:
+- Background darkest: oklch(11% 0.008 60) — very dark, warm brown-black
+- Card surface: oklch(17% 0.010 62) — slightly lighter warm dark
+- Accent/gold: oklch(68% 0.11 76) — amber candle-gold
+- Danger: oklch(47% 0.14 22) — rust red, bloodstained
+- Text primary: oklch(84% 0.009 75) — warm off-white
+- Text dim: oklch(58% 0.012 72) — muted warm mid-tone
+- All neutrals tinted toward hue 62 (warm amber family)
+
+### Design Principles
+1. **Archival precision** — every element earns its place; no decoration for decoration's sake; the interface is a ledger, not a stage set
+2. **Grim restraint** — atmosphere comes from color, weight, and typography — not from skulls and flourishes on every surface
+3. **Game-native, not game-themed** — feels built for Mordheim players specifically; a Mordheim player should feel it was made for them, not adapted from a generic template
+4. **Dark by default** — rich, warm, candlelit darkness is the primary experience; light mode is a concession, not the target
+5. **Function with flavour** — practical app UI that has character baked into its bones, not applied as a skin afterward

--- a/css/style.css
+++ b/css/style.css
@@ -1,58 +1,65 @@
 /* ===== MORDHEIM ROSTER APP - LIGHT PARCHMENT THEME ===== */
 
 :root {
-  --bg-darkest: #f5f0e8;
-  --bg-dark: #ece5d8;
-  --bg-card: #ffffff;
-  --bg-card-hover: #faf7f2;
-  --bg-input: #f8f5ef;
-  --border: #d4cabb;
-  --border-hover: #b8a98e;
-  --accent: #7f6110;
-  --accent-hover: #8f6c14;
-  --accent-dim: #a07e18;
-  --accent-glow: rgba(139, 105, 20, 0.12);
-  --danger: #b33a3a;
-  --danger-hover: #d04444;
-  --success: #2d7a2d;
-  --success-hover: #359435;
-  --text: #3d3529;
-  --text-dim: #6b6052;
-  --text-muted: #6f6250;
-  --text-bright: #2a231a;
-  --skull: #7f6110;
-  --shadow: rgba(100, 80, 40, 0.12);
-  --radius: 6px;
-  --radius-lg: 10px;
+  --bg-darkest: oklch(94% 0.016 78);
+  --bg-dark: oklch(90% 0.022 76);
+  --bg-card: oklch(99% 0.003 80);
+  --bg-card-hover: oklch(96% 0.010 79);
+  --bg-input: oklch(96% 0.010 80);
+  --border: oklch(81% 0.024 74);
+  --border-hover: oklch(70% 0.032 70);
+  --accent: oklch(45% 0.13 63);
+  --accent-hover: oklch(49% 0.14 64);
+  --accent-dim: oklch(53% 0.13 66);
+  --accent-glow: oklch(45% 0.13 63 / 0.12);
+  --danger: oklch(46% 0.155 18);
+  --danger-hover: oklch(52% 0.175 20);
+  --success: oklch(40% 0.14 148);
+  --success-hover: oklch(45% 0.15 148);
+  --text: oklch(24% 0.022 56);
+  --text-dim: oklch(41% 0.020 60);
+  --text-muted: oklch(42% 0.018 62);
+  --text-bright: oklch(16% 0.020 52);
+  --skill-color: oklch(38% 0.12 245);
+  --spell-color: oklch(38% 0.13 305);
+  --skull: oklch(45% 0.13 63);
+  --shadow: oklch(38% 0.020 60 / 0.12);
+  --radius: 4px;
+  --radius-lg: 8px;
   --transition: 0.2s ease;
-  --font-display: 'Cinzel', serif;
-  --treasury-positive: #7cb9a8;
-  --treasury-negative: #c87c7c;
+  --font-display: 'Pirata One', serif;
+  --font-body: 'Alegreya', Georgia, serif;
+  --treasury-positive: oklch(68% 0.08 183);
+  --treasury-negative: oklch(58% 0.12 22);
 }
 
 /* ===== DARK MODE THEME ===== */
 [data-theme="dark"] {
-  --bg-darkest: #1a1816;
-  --bg-dark: #242220;
-  --bg-card: #2e2b28;
-  --bg-card-hover: #36332f;
-  --bg-input: #242220;
-  --border: #3d3a36;
-  --border-hover: #5a5550;
-  --accent: #c9a033;
-  --accent-hover: #d4ab3d;
-  --accent-dim: #b89428;
-  --accent-glow: rgba(201, 160, 51, 0.15);
-  --danger: #d04444;
-  --danger-hover: #e05555;
-  --success: #3da63d;
-  --success-hover: #4ab84a;
-  --text: #e0dbd3;
-  --text-dim: #a39a8e;
-  --text-muted: #8a8078;
-  --text-bright: #f0ebe5;
-  --skull: #c9a033;
-  --shadow: rgba(0, 0, 0, 0.3);
+  --bg-darkest: oklch(11% 0.010 58);
+  --bg-dark: oklch(15% 0.011 60);
+  --bg-card: oklch(19% 0.012 61);
+  --bg-card-hover: oklch(23% 0.012 61);
+  --bg-input: oklch(13% 0.009 59);
+  --border: oklch(27% 0.013 62);
+  --border-hover: oklch(37% 0.017 64);
+  --accent: oklch(69% 0.115 72);
+  --accent-hover: oklch(73% 0.120 73);
+  --accent-dim: oklch(63% 0.105 70);
+  --accent-glow: oklch(69% 0.115 72 / 0.15);
+  --danger: oklch(52% 0.175 20);
+  --danger-hover: oklch(58% 0.185 21);
+  --success: oklch(58% 0.15 148);
+  --success-hover: oklch(63% 0.16 148);
+  --text: oklch(86% 0.010 76);
+  --text-dim: oklch(62% 0.013 73);
+  --text-muted: oklch(54% 0.011 70);
+  --text-bright: oklch(93% 0.007 80);
+  --skill-color: oklch(65% 0.12 240);
+  --spell-color: oklch(63% 0.13 300);
+  --skull: oklch(69% 0.115 72);
+  --shadow: oklch(5% 0.008 58 / 0.45);
+  --treasury-positive: oklch(71% 0.09 180);
+  --treasury-negative: oklch(67% 0.14 22);
 }
 
 *, *::before, *::after {
@@ -67,7 +74,7 @@ html {
 }
 
 body {
-  font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  font-family: var(--font-body);
   background: var(--bg-darkest);
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)' opacity='0.04'/%3E%3C/svg%3E");
   color: var(--text);
@@ -98,9 +105,9 @@ body {
 .app-title {
   font-family: var(--font-display);
   font-size: 1.5rem;
-  font-weight: 700;
+  font-weight: 400;
   color: var(--accent);
-  letter-spacing: 2px;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
   display: flex;
   align-items: center;
@@ -282,26 +289,10 @@ body {
   overflow: hidden;
 }
 
-.roster-card::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
-  background: linear-gradient(90deg, var(--accent-dim), var(--accent), var(--accent-dim));
-  opacity: 0;
-  transition: opacity var(--transition);
-}
-
 .roster-card:hover {
   border-color: var(--accent-dim);
-  transform: translateY(-2px) scale(1.005);
-  box-shadow: 0 4px 20px var(--shadow);
-}
-
-.roster-card:hover::before {
-  opacity: 1;
+  transform: translateY(-2px);
+  box-shadow: 0 8px 28px var(--shadow);
 }
 
 .roster-card-name {
@@ -588,13 +579,22 @@ select.form-control {
   margin-bottom: 0.8rem;
   overflow: hidden;
   transition: border-color var(--transition);
-  border-left: 3px solid var(--border);
 }
 
-.warrior-card--hero { border-left-color: var(--accent); }
-.warrior-card--henchman { border-left-color: var(--border-hover); }
-.warrior-card--hired { border-left-color: #3a6a9e; }
-.warrior-card--custom { border-left-color: #7a3e98; }
+.warrior-card--hero .warrior-card-header {
+  background: color-mix(in oklch, var(--accent) 7%, var(--bg-card));
+}
+.warrior-card--hired .warrior-card-header {
+  background: color-mix(in oklch, var(--skill-color) 7%, var(--bg-card));
+}
+.warrior-card--custom .warrior-card-header {
+  background: color-mix(in oklch, var(--spell-color) 7%, var(--bg-card));
+}
+
+.warrior-card--hero .warrior-name { font-family: var(--font-display); letter-spacing: 0.3px; }
+.warrior-card--hero .warrior-type { color: var(--accent-dim); }
+.warrior-card--hired .warrior-type { color: var(--skill-color); }
+.warrior-card--custom .warrior-type { color: var(--spell-color); }
 
 .warrior-card:hover {
   border-color: var(--border-hover);
@@ -606,7 +606,7 @@ select.form-control {
   justify-content: space-between;
   align-items: center;
   cursor: pointer;
-  background: rgba(139, 105, 20, 0.04);
+  background: var(--bg-card);
 }
 
 .warrior-card-header .warrior-name {
@@ -706,18 +706,18 @@ select.form-control {
 }
 
 .tag.skill {
-  border-color: #3a6a9e;
-  color: #2a5580;
+  border-color: var(--skill-color);
+  color: var(--skill-color);
 }
 
 .tag.spell-tag {
-  border-color: #7a3e98;
-  color: #6a2d88;
+  border-color: var(--spell-color);
+  color: var(--spell-color);
 }
 
 .tag.injury {
   border-color: var(--danger);
-  color: #a03030;
+  color: var(--danger);
 }
 
 .tag .tag-remove {
@@ -820,17 +820,17 @@ select.form-control {
 
 .treasury-type-badge--income,
 .treasury-type-badge--sell {
-  background: rgba(124, 185, 168, 0.15);
+  background: color-mix(in oklch, var(--treasury-positive) 15%, transparent);
   color: var(--treasury-positive);
 }
 
 .treasury-type-badge--purchase {
-  background: rgba(200, 124, 124, 0.15);
+  background: color-mix(in oklch, var(--treasury-negative) 15%, transparent);
   color: var(--treasury-negative);
 }
 
 .treasury-type-badge--other {
-  background: rgba(180, 180, 180, 0.1);
+  background: color-mix(in oklch, var(--text-dim) 10%, transparent);
   color: var(--text-dim);
 }
 
@@ -1635,7 +1635,7 @@ select.form-control {
 }
 
 .sync-synced {
-  background: #4a8;
+  background: var(--success);
 }
 
 .sync-error {
@@ -1665,15 +1665,15 @@ select.form-control {
 }
 
 .tier-standard {
-  background: #e8f0fe;
-  color: #1a5fb4;
-  border: 1px solid #a0c4ff;
+  background: color-mix(in oklch, oklch(52% 0.14 248) 12%, var(--bg-input));
+  color: oklch(52% 0.14 248);
+  border: 1px solid color-mix(in oklch, oklch(52% 0.14 248) 35%, transparent);
 }
 
 .tier-pro {
-  background: #fef3e0;
-  color: #b8600a;
-  border: 1px solid #f0c060;
+  background: color-mix(in oklch, var(--accent) 12%, var(--bg-input));
+  color: var(--accent);
+  border: 1px solid color-mix(in oklch, var(--accent-dim) 40%, transparent);
 }
 
 .tier-link {
@@ -1772,7 +1772,7 @@ select.form-control {
 }
 
 .tier-cell.tier-current {
-  background: rgba(139, 105, 20, 0.04);
+  background: color-mix(in oklch, var(--accent) 5%, transparent);
 }
 
 .tier-cell.tier-yes {
@@ -1822,42 +1822,7 @@ body, .app-header, .modal, .warrior-card, .roster-card,
   background: rgba(0, 0, 0, 0.65);
 }
 
-/* Tag colors — skill and spell need explicit dark overrides for contrast */
-[data-theme="dark"] .tag.skill {
-  border-color: #5a9ad4;
-  color: #7ab8e8;
-}
-
-[data-theme="dark"] .tag.spell-tag {
-  border-color: #a86cc4;
-  color: #c490de;
-}
-
-[data-theme="dark"] .tag.injury {
-  color: #e06060;
-}
-
-/* Treasury Ledger dark mode */
-[data-theme="dark"] .treasury-type-badge--income,
-[data-theme="dark"] .treasury-type-badge--sell {
-  color: #9dd4c2;
-}
-
-[data-theme="dark"] .treasury-type-badge--purchase {
-  color: #e09898;
-}
-
-[data-theme="dark"] .treasury-amount--positive {
-  color: #9dd4c2;
-}
-
-[data-theme="dark"] .treasury-amount--negative {
-  color: #e09898;
-}
-
-[data-theme="dark"] .treasury-delete-btn:hover {
-  color: #e09898;
-}
+/* Tag and treasury colors adapt automatically via CSS variables per theme */
 
 /* Theme toggle button */
 .btn-theme-toggle {

--- a/docs/superpowers/plans/2026-04-11-postgame-sequence.md
+++ b/docs/superpowers/plans/2026-04-11-postgame-sequence.md
@@ -1,0 +1,1406 @@
+# Post-Game Sequence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a guided post-game wizard (Pro tier) that walks the player through injuries, advancements, exploration, wyrdstone selling, hired sword upkeep, and trading post rolls after each battle.
+
+**Architecture:** A single `PostgameWizard` object in a new `js/postgame.js` file manages wizard state (current step, choices made, undo stack). `UI` calls `PostgameWizard.open(roster)` and the wizard renders into a reusable full-screen modal (`#postgame-modal`). Each step is a pure render function; state mutations happen only when the player confirms a step. Dice animations are self-contained CSS keyframe animations triggered by JS. All game-rule tables (injuries, advancements, income, exploration) live in `data/postgame.json`.
+
+**Tech Stack:** Vanilla JS, CSS keyframe animations for dice, existing `UI.esc/escAttr/toast`, `RosterModel` mutation helpers, `Storage.saveRoster`, `Cloud.canAccess`.
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `data/postgame.json` | Create | Income table, exploration chart summary, henchman availability table, trading post table |
+| `js/postgame.js` | Create | `PostgameWizard` object — all wizard logic and rendering |
+| `index.html` | Modify | Add `#postgame-modal` HTML skeleton, load `postgame.js`, add "Start Postgame Sequence" button in progress tab |
+| `js/ui.js` | Modify | Add `openPostgameWizard()` entry point, bump script cache version |
+| `css/style.css` | Modify | Dice animation styles, wizard step bar, postgame modal layout |
+| `data/version.json` | Modify | Bump version to force cache refresh |
+
+---
+
+## Task 1: Data file and feature gate
+
+**Files:**
+- Create: `data/postgame.json`
+- Modify: `js/cloud.js` (add `postgame_sequence` feature tier)
+- Modify: `data/version.json`
+
+- [ ] **Step 1: Create `data/postgame.json`**
+
+```json
+{
+  "incomeTable": [
+    { "warband": 3,  "gc": 2 },
+    { "warband": 4,  "gc": 3 },
+    { "warband": 5,  "gc": 4 },
+    { "warband": 6,  "gc": 6 },
+    { "warband": 7,  "gc": 8 },
+    { "warband": 8,  "gc": 10 },
+    { "warband": 9,  "gc": 12 },
+    { "warband": 10, "gc": 14 },
+    { "warband": 11, "gc": 16 },
+    { "warband": 12, "gc": 18 },
+    { "warband": 13, "gc": 20 },
+    { "warband": 14, "gc": 22 },
+    { "warband": 15, "gc": 24 }
+  ],
+  "henchmenAvailabilityTable": [
+    { "roll": "2",   "result": "D3 henchmen of any type already in warband" },
+    { "roll": "3",   "result": "1 henchman of any type already in warband" },
+    { "roll": "4-5", "result": "D3 of the cheapest henchman type available" },
+    { "roll": "6",   "result": "1 henchman of any type in the warband list" },
+    { "roll": "7-8", "result": "D3 henchmen of any type in the warband list" },
+    { "roll": "9",   "result": "D6 of the cheapest henchman type available" },
+    { "roll": "10-11","result": "D6 henchmen of any type in the warband list" },
+    { "roll": "12",  "result": "2D6 of the cheapest henchman type available" }
+  ],
+  "tradingPostTable": [
+    { "roll": "2",   "item": "Wyrdstone Pendulum", "cost": 30 },
+    { "roll": "3",   "item": "Daemonic Rune", "cost": 30 },
+    { "roll": "4",   "item": "Lucky Charm", "cost": 10 },
+    { "roll": "5",   "item": "Sword", "cost": 10 },
+    { "roll": "6",   "item": "Mace/Hammer", "cost": 3 },
+    { "roll": "7",   "item": "Dagger", "cost": 2 },
+    { "roll": "8",   "item": "Axe", "cost": 5 },
+    { "roll": "9",   "item": "Spear", "cost": 10 },
+    { "roll": "10",  "item": "Shield", "cost": 5 },
+    { "roll": "11",  "item": "Helmet", "cost": 10 },
+    { "roll": "12",  "item": "Light Armour", "cost": 20 }
+  ]
+}
+```
+
+- [ ] **Step 2: Add `postgame_sequence` to `FEATURE_TIERS` in `js/cloud.js`**
+
+In `js/cloud.js`, find the `FEATURE_TIERS` block and add:
+```js
+postgame_sequence: 'pro',
+```
+
+- [ ] **Step 3: Bump `data/version.json`**
+
+```json
+{ "version": 2 }
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add data/postgame.json js/cloud.js data/version.json
+git commit -m "feat: add postgame data file and feature gate"
+```
+
+---
+
+## Task 2: Modal HTML skeleton and CSS
+
+**Files:**
+- Modify: `index.html`
+- Modify: `css/style.css`
+
+- [ ] **Step 1: Add `#postgame-modal` to `index.html`**
+
+In `index.html`, just before the closing `</body>` tag, add:
+
+```html
+<!-- Post-Game Sequence Wizard Modal -->
+<div id="postgame-modal" class="modal-overlay" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="postgame-modal-title">
+  <div class="modal-box postgame-modal-box">
+    <div class="postgame-header">
+      <h2 id="postgame-modal-title" class="postgame-title">Post-Game Sequence</h2>
+      <button class="modal-close-btn" onclick="PostgameWizard.close()" aria-label="Close">&times;</button>
+    </div>
+    <div class="postgame-progress-bar" id="postgame-progress-bar">
+      <!-- Step indicators rendered by JS -->
+    </div>
+    <div class="postgame-body" id="postgame-body">
+      <!-- Step content rendered by JS -->
+    </div>
+    <div class="postgame-footer" id="postgame-footer">
+      <!-- Navigation buttons rendered by JS -->
+    </div>
+  </div>
+</div>
+```
+
+- [ ] **Step 2: Add dice animation and wizard styles to `css/style.css`**
+
+Append to the end of `css/style.css` (before the final dark mode overrides):
+
+```css
+/* ===== POST-GAME WIZARD ===== */
+.postgame-modal-box {
+  width: min(96vw, 680px);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+}
+.postgame-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+}
+.postgame-title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+.postgame-progress-bar {
+  display: flex;
+  gap: 0;
+  padding: 0.5rem 1.25rem;
+  background: var(--bg-dark);
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+}
+.postgame-step-indicator {
+  flex: 1;
+  min-width: 60px;
+  text-align: center;
+  font-size: 0.65rem;
+  color: var(--text-dim);
+  position: relative;
+  padding-bottom: 0.4rem;
+}
+.postgame-step-indicator::after {
+  content: '';
+  display: block;
+  height: 3px;
+  background: var(--border);
+  margin-top: 0.25rem;
+  border-radius: 2px;
+}
+.postgame-step-indicator.is-done::after  { background: var(--primary); }
+.postgame-step-indicator.is-active { color: var(--primary); font-weight: 700; }
+.postgame-step-indicator.is-active::after { background: var(--primary); }
+.postgame-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem 1.25rem;
+}
+.postgame-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  border-top: 1px solid var(--border);
+  background: var(--bg-dark);
+}
+
+/* Dice */
+.dice-tray {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  margin: 1rem 0;
+}
+.die {
+  width: 52px;
+  height: 52px;
+  border: 2px solid var(--primary);
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+  font-weight: 700;
+  background: var(--bg-card);
+  cursor: pointer;
+  user-select: none;
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+.die:hover { transform: scale(1.06); box-shadow: 0 2px 8px rgba(0,0,0,0.25); }
+.die.is-rolling { animation: diceRoll 0.5s ease-out; }
+.die.is-locked { border-color: var(--success, #4caf50); opacity: 0.7; }
+@keyframes diceRoll {
+  0%   { transform: rotate(0deg) scale(1); }
+  25%  { transform: rotate(-15deg) scale(1.1); }
+  50%  { transform: rotate(12deg) scale(0.95); }
+  75%  { transform: rotate(-8deg) scale(1.05); }
+  100% { transform: rotate(0deg) scale(1); }
+}
+
+/* Warrior checklist */
+.postgame-warrior-list { list-style: none; padding: 0; margin: 0; }
+.postgame-warrior-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--border);
+}
+.postgame-warrior-item:last-child { border-bottom: none; }
+.postgame-warrior-item label { flex: 1; cursor: pointer; }
+.postgame-advancement-result {
+  background: var(--bg-dark);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin-top: 0.5rem;
+}
+```
+
+- [ ] **Step 3: Add "Start Postgame Sequence" button in `index.html` progress tab**
+
+Find the battle log section header in `index.html` (look for `id="battle-log-entries"`) and add the button just above the `<!-- BATTLE LOG -->` section comment or at the top of the progress-tab content:
+
+```html
+<div id="postgame-btn-container" style="margin-bottom:1rem;">
+  <button class="btn btn-primary" id="btn-start-postgame" onclick="UI.openPostgameWizard()">
+    &#9876; Start Post-Game Sequence
+  </button>
+</div>
+```
+
+- [ ] **Step 4: Load `postgame.js` in `index.html`**
+
+After the `<script src="js/ui.js?v=41">` tag, add:
+```html
+<script src="js/postgame.js?v=1"></script>
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add index.html css/style.css
+git commit -m "feat: add postgame modal skeleton, dice animation CSS, and trigger button"
+```
+
+---
+
+## Task 3: PostgameWizard core (state machine + step 1 — Out of Action)
+
+**Files:**
+- Create: `js/postgame.js`
+
+The wizard holds state in `PostgameWizard._state`, which is a plain object that is reset on each `open()` call. Steps are numbered 1–7. Navigation calls `_renderStep(n)`.
+
+- [ ] **Step 1: Create `js/postgame.js` with core structure and Step 1**
+
+```js
+// Post-Game Sequence Wizard
+// Guides the player through injuries, advancements, exploration, wyrdstone,
+// hired sword upkeep, henchman availability, and trading post rolls.
+const PostgameWizard = {
+  _state: null,
+
+  STEPS: [
+    'Out of Action',
+    'Injuries',
+    'Advancements',
+    'Exploration',
+    'Hired Swords',
+    'Henchmen',
+    'Trading Post',
+  ],
+
+  open(roster) {
+    this._state = {
+      roster,
+      outOfAction: [],      // warrior objects taken OOA
+      injuryResults: [],    // [{ warrior, rolls, injuries }]
+      advancementResults: [],// [{ warrior, rolls, result }]
+      explorationDice: [],  // final die values
+      wyrdstoneEarned: 0,
+      undoStack: [],        // [snapshot of roster state as JSON string]
+    };
+    document.getElementById('postgame-modal').style.display = '';
+    this._renderStep(1);
+  },
+
+  close() {
+    document.getElementById('postgame-modal').style.display = 'none';
+    this._state = null;
+  },
+
+  _pushUndo() {
+    const r = this._state.roster;
+    this._state.undoStack.push(JSON.stringify({
+      gold: r.gold, wyrdstone: r.wyrdstone,
+      heroes: r.heroes, henchmen: r.henchmen, hiredSwords: r.hiredSwords,
+      treasuryLog: r.treasuryLog,
+    }));
+  },
+
+  _undo() {
+    if (!this._state.undoStack.length) return;
+    const snapshot = JSON.parse(this._state.undoStack.pop());
+    const r = this._state.roster;
+    Object.assign(r, snapshot);
+    Storage.saveRoster(r);
+    UI.renderRosterEditor();
+    UI.toast('Undone.', 'info');
+  },
+
+  // ── Rendering ──────────────────────────────────────────────────────────────
+
+  _renderProgressBar(activeStep) {
+    const bar = document.getElementById('postgame-progress-bar');
+    bar.innerHTML = this.STEPS.map((label, i) => {
+      const n = i + 1;
+      let cls = 'postgame-step-indicator';
+      if (n < activeStep) cls += ' is-done';
+      if (n === activeStep) cls += ' is-active';
+      return `<div class="${cls}">${n}. ${UI.esc(label)}</div>`;
+    }).join('');
+  },
+
+  _setFooter(html) {
+    document.getElementById('postgame-footer').innerHTML = html;
+  },
+
+  _setBody(html) {
+    document.getElementById('postgame-body').innerHTML = html;
+  },
+
+  _renderStep(n) {
+    this._renderProgressBar(n);
+    switch (n) {
+      case 1: this._renderStep1(); break;
+      case 2: this._renderStep2(); break;
+      case 3: this._renderStep3(); break;
+      case 4: this._renderStep4(); break;
+      case 5: this._renderStep5(); break;
+      case 6: this._renderStep6(); break;
+      case 7: this._renderStep7(); break;
+    }
+  },
+
+  // ── Step 1: Out of Action ─────────────────────────────────────────────────
+
+  _renderStep1() {
+    const r = this._state.roster;
+    // Expand henchmen groups into one entry per model so each model
+    // can be independently checked as OOA (a group of 3 can have 2 OOA).
+    const allWarriors = [
+      ...r.heroes.map(w => ({ w, listType: 'heroes', modelIndex: null })),
+      ...(r.hiredSwords || []).map(w => ({ w, listType: 'hiredSwords', modelIndex: null })),
+      ...r.henchmen.flatMap(w =>
+        Array.from({ length: w.groupSize || 1 }, (_, mi) => ({ w, listType: 'henchmen', modelIndex: mi }))
+      ),
+    ];
+    this._setBody(`
+      <p>Check the warriors who were <strong>taken out of action</strong> this battle.
+         Henchmen groups are listed per individual model.</p>
+      <ul class="postgame-warrior-list" id="ooa-list">
+        ${allWarriors.map(({ w, listType, modelIndex }, i) => {
+          const isHenchman = listType === 'henchmen';
+          const modelLabel = isHenchman ? `${UI.esc(w.typeName)} #${modelIndex + 1}` : UI.esc(w.name);
+          const subLabel = isHenchman ? `<span class="text-dim">(Henchman · ${w.experience} XP)</span>` : `<span class="text-dim">(${UI.esc(w.typeName)})</span>`;
+          return `<li class="postgame-warrior-item">
+            <input type="checkbox" id="ooa-${i}" data-idx="${i}">
+            <label for="ooa-${i}">${modelLabel} ${subLabel}</label>
+          </li>`;
+        }).join('')}
+      </ul>
+      <p class="text-dim" style="margin-top:0.75rem; font-size:0.82rem;">
+        Heroes not taken out of action contribute exploration dice in Step 4.
+      </p>
+    `);
+    this._setFooter(`
+      <button class="btn btn-secondary" onclick="PostgameWizard.close()">Cancel</button>
+      <button class="btn btn-primary" onclick="PostgameWizard._confirmStep1()">Next &rsaquo;</button>
+    `);
+  },
+
+  _confirmStep1() {
+    const r = this._state.roster;
+    const allWarriors = [
+      ...r.heroes.map(w => ({ w, listType: 'heroes', modelIndex: null })),
+      ...(r.hiredSwords || []).map(w => ({ w, listType: 'hiredSwords', modelIndex: null })),
+      ...r.henchmen.flatMap(w =>
+        Array.from({ length: w.groupSize || 1 }, (_, mi) => ({ w, listType: 'henchmen', modelIndex: mi }))
+      ),
+    ];
+    const checked = [...document.querySelectorAll('#ooa-list input:checked')].map(el => {
+      return allWarriors[parseInt(el.dataset.idx)];
+    });
+    this._state.outOfAction = checked;
+    this._renderStep(2);
+  },
+};
+```
+
+- [ ] **Step 2: Verify the modal opens and Step 1 renders (manual test)**
+
+Open the app, navigate to the Progress tab, click "Start Post-Game Sequence". Verify:
+- Modal appears with progress bar showing Step 1 active
+- All warriors from heroes/henchmen/hiredSwords appear as checkboxes
+- "Next" button advances (may not render Step 2 yet — that's OK for this task)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add js/postgame.js
+git commit -m "feat: postgame wizard core — step 1 out-of-action checklist"
+```
+
+---
+
+## Task 4: Step 2 — Injury rolls
+
+**Files:**
+- Modify: `js/postgame.js`
+
+Injury rules from `data/injuries.json`: heroes roll 2D6 on `heroInjuries` table; henchmen roll 1D6 on `henchmenInjuries` table. "Multiple Injuries" (roll 16-21) means roll D6 more times on the serious injury table.
+
+Dice are shown as animated tiles. Player clicks "Roll for me" per warrior OR enters manually. Player must confirm before the injury is applied. Applying "Dead" removes the warrior. Applying "Misses Next Game" sets `warrior.missNextGame = true`. Stat-reducing injuries (Leg Wound, Arm Wound etc.) call `RosterModel.modifyStat()`.
+
+- [ ] **Step 1: Add `_renderStep2()` to `PostgameWizard`**
+
+Add inside the `PostgameWizard` object after `_confirmStep1`:
+
+```js
+// ── Step 2: Injuries ──────────────────────────────────────────────────────
+
+_renderStep2() {
+  const ooa = this._state.outOfAction;
+  if (ooa.length === 0) {
+    this._setBody('<p>No warriors were taken out of action — skip to advancements.</p>');
+    this._setFooter(`
+      <button class="btn btn-secondary" onclick="PostgameWizard._renderStep(1)">&lsaquo; Back</button>
+      <button class="btn btn-primary" onclick="PostgameWizard._renderStep(3)">Next &rsaquo;</button>
+    `);
+    return;
+  }
+
+  // Build per-warrior injury panels, cycling through each OOA warrior
+  this._state._injuryIdx = this._state._injuryIdx ?? 0;
+  const idx = this._state._injuryIdx;
+  if (idx >= ooa.length) {
+    this._renderStep(3);
+    return;
+  }
+  const { w, listType } = ooa[idx];
+  const isHero = listType === 'heroes' || listType === 'hiredSwords' || listType === 'customWarriors';
+  const diceCount = isHero ? 2 : 1;
+  const dice = this._state._injuryDice || Array(diceCount).fill(null);
+
+  this._setBody(`
+    <p><strong>${UI.esc(w.name)}</strong> was taken out of action.
+    Roll ${isHero ? '2D6 on the hero injury table' : '1D6 on the henchman injury table'}.</p>
+    <div class="dice-tray" id="injury-dice-tray">
+      ${dice.map((v, i) => `
+        <div class="die${v === null ? '' : ''}" id="injury-die-${i}" onclick="PostgameWizard._rerollInjuryDie(${i})">
+          ${v === null ? '?' : v}
+        </div>
+      `).join('')}
+    </div>
+    <div id="injury-result-display"></div>
+    <p class="text-dim" style="font-size:0.8rem; margin-top:0.5rem;">Click a die to reroll it. Click "Roll All" to roll all dice.</p>
+  `);
+
+  this._setFooter(`
+    <button class="btn btn-secondary" onclick="PostgameWizard._renderStep(1)">&lsaquo; Back</button>
+    <button class="btn btn-secondary" onclick="PostgameWizard._rollAllInjuryDice()">&#127922; Roll All</button>
+    ${dice.every(v => v !== null) ? `<button class="btn btn-primary" onclick="PostgameWizard._confirmInjury()">Apply &amp; Next &rsaquo;</button>` : ''}
+  `);
+},
+
+_rollAllInjuryDice() {
+  const ooa = this._state.outOfAction;
+  const { w, listType } = ooa[this._state._injuryIdx];
+  const isHero = listType === 'heroes' || listType === 'hiredSwords' || listType === 'customWarriors';
+  const count = isHero ? 2 : 1;
+  this._state._injuryDice = Array.from({ length: count }, () => Math.floor(Math.random() * 6) + 1);
+  this._animateDice('injury-dice-tray', this._state._injuryDice, () => this._renderStep2());
+},
+
+_rerollInjuryDie(i) {
+  if (!this._state._injuryDice) this._state._injuryDice = [null, null];
+  this._state._injuryDice[i] = Math.floor(Math.random() * 6) + 1;
+  this._animateDice('injury-dice-tray', this._state._injuryDice, () => this._renderStep2());
+},
+
+_animateDice(trayId, values, callback) {
+  const tray = document.getElementById(trayId);
+  if (!tray) { callback(); return; }
+  tray.querySelectorAll('.die').forEach((el, i) => {
+    el.classList.add('is-rolling');
+    el.textContent = values[i] ?? '?';
+  });
+  setTimeout(() => {
+    tray.querySelectorAll('.die').forEach(el => el.classList.remove('is-rolling'));
+    callback();
+  }, 550);
+},
+
+_resolveInjuryRoll(dice, isHero) {
+  const injuries = DataService.injuries;
+  const total = dice.reduce((a, b) => a + b, 0);
+  const table = isHero ? injuries.heroInjuries : injuries.henchmenInjuries;
+  for (const row of table) {
+    const range = row.roll.toString();
+    if (range.includes('-')) {
+      const [lo, hi] = range.split('-').map(Number);
+      if (total >= lo && total <= hi) return row;
+    } else if (parseInt(range) === total) {
+      return row;
+    }
+  }
+  return null;
+},
+
+_confirmInjury() {
+  const ooa = this._state.outOfAction;
+  const idx = this._state._injuryIdx;
+  const { w, listType } = ooa[idx];
+  const isHero = listType === 'heroes' || listType === 'hiredSwords' || listType === 'customWarriors';
+  const dice = this._state._injuryDice;
+  const total = dice.reduce((a, b) => a + b, 0);
+  const row = this._resolveInjuryRoll(dice, isHero);
+  if (!row) { UI.toast('Could not resolve injury roll.', 'error'); return; }
+
+  this._pushUndo();
+  this._applyInjury(w, listType, row, total, isHero);
+  Storage.saveRoster(this._state.roster);
+  UI.renderRosterEditor();
+
+  this._state.injuryResults.push({ warrior: w, dice, injury: row });
+  this._state._injuryIdx = idx + 1;
+  this._state._injuryDice = null;
+  this._renderStep2();
+},
+
+_applyInjury(w, listType, row, total, isHero) {
+  const r = this._state.roster;
+  switch (row.name) {
+    case 'Dead':
+      if (listType === 'henchmen') {
+        // Reduce group size by 1; remove group only when it reaches 0
+        w.groupSize = (w.groupSize || 1) - 1;
+        if (w.groupSize <= 0) r.henchmen.splice(r.henchmen.indexOf(w), 1);
+        UI.toast(`${w.typeName} #${(w.groupSize || 0) + 1} died.`, 'error');
+      } else {
+        // Heroes and hired swords: mark dead, keep in roster so player can see
+        // and choose when to replace. Dead heroes do NOT count toward hero cap,
+        // warband rating, or member count.
+        w.isDead = true;
+        w.missNextGame = false; // irrelevant now
+        UI.toast(`${w.name} is dead.`, 'error');
+      }
+      break;
+    case 'Full Recovery':
+      // Nothing to apply
+      break;
+    case 'Misses Next Game':
+    case 'Deep Wound':
+      w.missNextGame = true;
+      RosterModel.addInjury(w, row.name);
+      break;
+    case 'Leg Wound':
+    case 'Smashed Leg':
+      RosterModel.modifyStat(w, 'm', -1);
+      RosterModel.addInjury(w, row.name);
+      break;
+    case 'Arm Wound':
+    case 'Hand Injury':
+      RosterModel.modifyStat(w, 'ws', -1);
+      RosterModel.addInjury(w, row.name);
+      break;
+    case 'Chest Wound':
+      RosterModel.modifyStat(w, 't', -1);
+      RosterModel.addInjury(w, row.name);
+      break;
+    case 'Blinded in One Eye':
+      RosterModel.modifyStat(w, 'bs', -1);
+      RosterModel.addInjury(w, row.name);
+      break;
+    case 'Nervous Condition':
+      RosterModel.modifyStat(w, 'i', -1);
+      RosterModel.addInjury(w, row.name);
+      break;
+    case 'Sold to the Pits':
+      RosterModel.addExperience(w, Math.floor(Math.random() * 6) + 1);
+      RosterModel.addInjury(w, row.name);
+      break;
+    case 'Survives Against the Odds':
+      RosterModel.addExperience(w, 1);
+      break;
+    case 'Robbed':
+      w.equipment = [];
+      RosterModel.addInjury(w, row.name);
+      break;
+    default:
+      RosterModel.addInjury(w, row.name);
+      break;
+  }
+},
+```
+
+- [ ] **Step 2: Verify Step 2 manually**
+
+Open the wizard, check one hero OOA, click Next. Verify:
+- Hero injury panel appears with 2 animated dice tiles
+- "Roll All" triggers animation and shows result
+- Clicking a die rerolls just that die
+- "Apply & Next" cycles to the next OOA warrior, then advances to Step 3
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add js/postgame.js
+git commit -m "feat: postgame step 2 — injury rolls with dice animation and apply"
+```
+
+---
+
+## Task 5: Step 3 — Advancements
+
+**Files:**
+- Modify: `js/postgame.js`
+
+Rules from `data/advancement.json`: heroes roll 2D6 on `heroAdvancement.advanceRoll`; henchmen roll 2D6 on `henchmenAdvancement.advanceRoll`. A warrior only rolls if they have enough XP for their next threshold. "Roll Again (Two Stats)" means roll twice and apply both (not the same result twice). If the result is "New Skill", show the skill picker immediately. Max stat check via `DataService.getMaxStat()` blocks over-max stat grants. Player can reroll once by clicking a die.
+
+- [ ] **Step 1: Add `_renderStep3()` and helpers**
+
+Add inside `PostgameWizard` after the Step 2 methods:
+
+```js
+// ── Step 3: Advancements ──────────────────────────────────────────────────
+
+_renderStep3() {
+  const r = this._state.roster;
+  // Collect warriors who have crossed a new threshold since last advancementCount
+  // (advancement is triggered if level > advancementCount — simplified: show all)
+  const eligible = [
+    ...r.heroes.map(w => ({ w, listType: 'heroes' })),
+    ...(r.hiredSwords || []).map(w => ({ w, listType: 'hiredSwords' })),
+    ...r.henchmen.map(w => ({ w, listType: 'henchmen' })),
+  ].filter(({ w, listType }) => {
+    const isHero = listType !== 'henchmen';
+    const level = isHero
+      ? RosterModel.getHeroLevel(w.experience)
+      : RosterModel.getHenchmanLevel(w.experience);
+    return level > (w.advancementCount || 0);
+  });
+
+  this._state._advIdx = this._state._advIdx ?? 0;
+  const idx = this._state._advIdx;
+  if (idx >= eligible.length) {
+    this._setBody(eligible.length === 0
+      ? '<p>No warriors are due for an advancement roll.</p>'
+      : '<p>All advancements processed.</p>');
+    this._setFooter(`
+      <button class="btn btn-secondary" onclick="PostgameWizard._renderStep(2)">&lsaquo; Back</button>
+      <button class="btn btn-primary" onclick="PostgameWizard._renderStep(4)">Next &rsaquo;</button>
+    `);
+    return;
+  }
+
+  const { w, listType } = eligible[idx];
+  const isHero = listType !== 'henchmen';
+  const dice = this._state._advDice || [null, null];
+  const total = dice.every(v => v !== null) ? dice[0] + dice[1] : null;
+  const advRow = total !== null ? this._resolveAdvancementRoll(total, isHero, w) : null;
+
+  this._setBody(`
+    <p><strong>${UI.esc(w.name)}</strong> is due for an advancement (${w.experience} XP).
+    Roll 2D6 on the ${isHero ? 'hero' : 'henchman'} advancement table.</p>
+    <div class="dice-tray" id="adv-dice-tray">
+      ${dice.map((v, i) => `<div class="die" id="adv-die-${i}" onclick="PostgameWizard._rerollAdvDie(${i})">${v === null ? '?' : v}</div>`).join('')}
+    </div>
+    ${advRow ? `
+      <div class="postgame-advancement-result">
+        <strong>${UI.esc(advRow.name)}</strong>
+        <p style="margin:0.25rem 0 0; font-size:0.85rem;">${UI.esc(advRow.description)}</p>
+        ${advRow.name === 'New Skill' ? this._renderSkillPicker(w) : ''}
+      </div>
+    ` : ''}
+  `);
+
+  this._setFooter(`
+    <button class="btn btn-secondary" onclick="PostgameWizard._renderStep(2)">&lsaquo; Back</button>
+    <button class="btn btn-secondary" onclick="PostgameWizard._rollAllAdvDice()">&#127922; Roll All</button>
+    ${advRow ? `<button class="btn btn-primary" onclick="PostgameWizard._confirmAdvancement()">Apply &amp; Next &rsaquo;</button>` : ''}
+  `);
+},
+
+_rollAllAdvDice() {
+  this._state._advDice = [Math.floor(Math.random() * 6) + 1, Math.floor(Math.random() * 6) + 1];
+  this._animateDice('adv-dice-tray', this._state._advDice, () => this._renderStep3());
+},
+
+_rerollAdvDie(i) {
+  if (!this._state._advDice) this._state._advDice = [null, null];
+  this._state._advDice[i] = Math.floor(Math.random() * 6) + 1;
+  this._animateDice('adv-dice-tray', this._state._advDice, () => this._renderStep3());
+},
+
+_resolveAdvancementRoll(total, isHero, w) {
+  const table = isHero
+    ? DataService.advancement.heroAdvancement.advanceRoll
+    : DataService.advancement.henchmenAdvancement.advanceRoll;
+  for (const [range, row] of Object.entries(table)) {
+    if (range.includes('-')) {
+      const [lo, hi] = range.split('-').map(Number);
+      if (total >= lo && total <= hi) return row;
+    } else if (parseInt(range) === total) {
+      return row;
+    }
+  }
+  return null;
+},
+
+_renderSkillPicker(w) {
+  if (!w.skillAccess || !w.skillAccess.length) return '<p class="text-dim">No skill access defined.</p>';
+  const sections = w.skillAccess.map(subtype => {
+    const skills = DataService.getSkillsBySubtype(subtype, null)
+      .filter(s => !w.skills.find(es => es.id === DataService.slugify(s.name)));
+    if (!skills.length) return '';
+    return `<optgroup label="${UI.escAttr(subtype)}">
+      ${skills.map(s => `<option value="${UI.escAttr(DataService.slugify(s.name))}">${UI.esc(s.name)}</option>`).join('')}
+    </optgroup>`;
+  }).join('');
+  return `<div style="margin-top:0.5rem;">
+    <label>Select skill:</label>
+    <select id="adv-skill-select" class="form-control" style="margin-top:0.25rem;">${sections}</select>
+  </div>`;
+},
+
+_confirmAdvancement() {
+  const r = this._state.roster;
+  const eligible = [
+    ...r.heroes.map(w => ({ w, listType: 'heroes' })),
+    ...(r.hiredSwords || []).map(w => ({ w, listType: 'hiredSwords' })),
+    ...r.henchmen.map(w => ({ w, listType: 'henchmen' })),
+  ].filter(({ w, listType }) => {
+    const isHero = listType !== 'henchmen';
+    const level = isHero ? RosterModel.getHeroLevel(w.experience) : RosterModel.getHenchmanLevel(w.experience);
+    return level > (w.advancementCount || 0);
+  });
+
+  const idx = this._state._advIdx;
+  const { w, listType } = eligible[idx];
+  const isHero = listType !== 'henchmen';
+  const dice = this._state._advDice;
+  const total = dice[0] + dice[1];
+  const advRow = this._resolveAdvancementRoll(total, isHero, w);
+  if (!advRow) return;
+
+  this._pushUndo();
+
+  if (advRow.name === 'New Skill') {
+    const sel = document.getElementById('adv-skill-select');
+    if (sel && sel.value) RosterModel.addSkill(w, sel.value);
+  } else if (advRow.name === 'Roll Again (Two Stats)') {
+    // Roll twice more — recurse into a sub-roll (simplified: apply both in sequence)
+    UI.toast('Roll Again: roll twice more on the table and apply each result.', 'info');
+  } else {
+    // Apply stat boost
+    const statMap = {
+      '+1 Strength': ['s', 1], '+1 Attack': ['a', 1], '+1 BS': ['bs', 1],
+      '+1 WS': ['ws', 1], '+1 Initiative': ['i', 1], '+1 Leadership': ['ld', 1],
+      '+1 Wound': ['w', 1],
+    };
+    const [stat, delta] = statMap[advRow.name] || [null, 0];
+    if (stat) {
+      const applied = RosterModel.modifyStat(w, stat, delta);
+      if (!applied) UI.toast(`${w.name} is already at max ${stat.toUpperCase()}.`, 'warning');
+    }
+  }
+
+  w.advancementCount = (w.advancementCount || 0) + 1;
+  Storage.saveRoster(r);
+  UI.renderRosterEditor();
+
+  this._state.advancementResults.push({ warrior: w, dice, result: advRow });
+  this._state._advIdx = idx + 1;
+  this._state._advDice = null;
+  this._renderStep3();
+},
+```
+
+- [ ] **Step 2: Verify Step 3 manually**
+
+Artificially give a hero enough XP to trigger advancement in the JSON (edit localStorage). Open wizard, reach Step 3. Verify:
+- Warrior name and XP shown
+- Dice animate
+- Result label appears after roll
+- If "New Skill", dropdown appears with available skills
+- "Apply & Next" applies the advancement and shows next warrior
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add js/postgame.js
+git commit -m "feat: postgame step 3 — advancement rolls with skill picker"
+```
+
+---
+
+## Task 6: Step 4 — Exploration
+
+**Files:**
+- Modify: `js/postgame.js`
+- Modify: `data/postgame.json` (no changes needed — income table already there)
+
+Rules: Only heroes not taken out of action contribute an exploration die each. +1 die for winning the scenario. Player may add extra dice manually. Player can lock dice (keep) and reroll the rest. Final result: sum all dice; identify highest number of doubles (or triples). Confirm result. Add wyrdstone shards to `roster.wyrdstone` via treasury log. Then show income table: compute warband size excluding hired swords + dramatis personae (warriors with `isHiredSword: true`), look up GC from `postgame.incomeTable`, offer to sell all wyrdstone at that rate.
+
+- [ ] **Step 1: Add `_renderStep4()` and helpers**
+
+Add inside `PostgameWizard` after Step 3 methods:
+
+```js
+// ── Step 4: Exploration ───────────────────────────────────────────────────
+
+_renderStep4() {
+  const r = this._state.roster;
+  const ooa = this._state.outOfAction.map(e => e.w);
+  const activeHeroes = r.heroes.filter(h => !ooa.includes(h));
+  const baseDiceCount = activeHeroes.length;
+
+  if (!this._state._exploreSetup) {
+    this._state._exploreSetup = {
+      extraDice: 0,
+      wonScenario: false,
+      dice: null,        // array of { value, locked }
+      confirmed: false,
+    };
+  }
+  const setup = this._state._exploreSetup;
+  const totalDice = baseDiceCount + (setup.wonScenario ? 1 : 0) + setup.extraDice;
+
+  const diceHtml = setup.dice
+    ? setup.dice.map((d, i) => `
+        <div class="die${d.locked ? ' is-locked' : ''}" onclick="PostgameWizard._toggleExploreLock(${i})" title="${d.locked ? 'Locked — click to unlock' : 'Click to lock'}">
+          ${d.value}
+        </div>`).join('')
+    : Array(totalDice).fill(0).map((_, i) => `<div class="die" id="ed-${i}">?</div>`).join('');
+
+  const doublesInfo = setup.dice ? this._analyzeExploreDice(setup.dice.map(d => d.value)) : null;
+
+  this._setBody(`
+    <p><strong>Exploration</strong> — ${activeHeroes.length} active hero(es) = ${baseDiceCount} base dice.</p>
+    <div style="display:flex; gap:1rem; align-items:center; flex-wrap:wrap; margin-bottom:0.75rem;">
+      <label><input type="checkbox" id="explore-won" ${setup.wonScenario ? 'checked' : ''}
+        onchange="PostgameWizard._toggleWon()"> Won the scenario (+1 die)</label>
+      <label>Extra dice:
+        <input type="number" id="explore-extra" value="${setup.extraDice}" min="0" max="10" style="width:50px; margin-left:0.25rem;"
+          onchange="PostgameWizard._setExtraDice(this.value)">
+      </label>
+    </div>
+    <p class="text-dim" style="font-size:0.8rem;">Total dice: <strong>${totalDice}</strong>.
+      Click a die after rolling to lock/unlock it for rerolling.</p>
+    <div class="dice-tray" id="explore-dice-tray">${diceHtml}</div>
+    ${doublesInfo ? `<div class="postgame-advancement-result">
+      <strong>Total: ${doublesInfo.total}</strong>
+      ${doublesInfo.triples.length ? `<br>Triples: ${doublesInfo.triples.join(', ')}` : ''}
+      ${doublesInfo.doubles.length ? `<br>Doubles: ${doublesInfo.doubles.join(', ')}` : ''}
+    </div>` : ''}
+  `);
+
+  this._setFooter(`
+    <button class="btn btn-secondary" onclick="PostgameWizard._renderStep(3)">&lsaquo; Back</button>
+    <button class="btn btn-secondary" onclick="PostgameWizard._rollExploreDice()">&#127922; Roll Unlocked</button>
+    ${doublesInfo ? `<button class="btn btn-primary" onclick="PostgameWizard._confirmExploration()">Confirm Exploration &rsaquo;</button>` : ''}
+  `);
+},
+
+_toggleWon() {
+  this._state._exploreSetup.wonScenario = document.getElementById('explore-won').checked;
+  this._state._exploreSetup.dice = null;
+  this._renderStep4();
+},
+
+_setExtraDice(val) {
+  this._state._exploreSetup.extraDice = Math.max(0, parseInt(val) || 0);
+  this._state._exploreSetup.dice = null;
+  this._renderStep4();
+},
+
+_toggleExploreLock(i) {
+  const dice = this._state._exploreSetup.dice;
+  if (!dice || dice[i].value === null) return;
+  dice[i].locked = !dice[i].locked;
+  this._renderStep4();
+},
+
+_rollExploreDice() {
+  const setup = this._state._exploreSetup;
+  const r = this._state.roster;
+  const ooa = this._state.outOfAction.map(e => e.w);
+  const total = r.heroes.filter(h => !ooa.includes(h)).length
+    + (setup.wonScenario ? 1 : 0) + setup.extraDice;
+
+  if (!setup.dice) {
+    setup.dice = Array(total).fill(0).map(() => ({ value: null, locked: false }));
+  }
+  setup.dice.forEach(d => { if (!d.locked) d.value = Math.floor(Math.random() * 6) + 1; });
+  const vals = setup.dice.map(d => d.value);
+  this._animateDice('explore-dice-tray', vals, () => this._renderStep4());
+},
+
+_analyzeExploreDice(values) {
+  const counts = {};
+  for (const v of values) counts[v] = (counts[v] || 0) + 1;
+  const doubles = Object.entries(counts).filter(([, c]) => c === 2).map(([v]) => parseInt(v));
+  const triples = Object.entries(counts).filter(([, c]) => c >= 3).map(([v]) => parseInt(v));
+  return { total: values.reduce((a, b) => a + b, 0), doubles, triples };
+},
+
+_confirmExploration() {
+  const setup = this._state._exploreSetup;
+  const values = setup.dice.map(d => d.value);
+  const { total, doubles, triples } = this._analyzeExploreDice(values);
+
+  // Wyrdstone shards = total (standard Mordheim rule)
+  const shards = total;
+  this._state.wyrdstoneEarned = shards;
+
+  this._pushUndo();
+  const r = this._state.roster;
+  r.wyrdstone = (r.wyrdstone || 0) + shards;
+  r.treasuryLog = r.treasuryLog || [];
+  r.treasuryLog.push({
+    id: Storage.generateId(),
+    type: 'income',
+    description: `Exploration: found ${shards} wyrdstone shard${shards !== 1 ? 's' : ''}`,
+    gold: 0,
+    wyrdstone: shards,
+    applied: true,
+    date: new Date().toISOString(),
+    actualGoldDelta: 0,
+    actualWyrdstoneDelta: shards,
+  });
+
+  // Show sell prompt
+  this._renderStep4Sell(shards, doubles, triples);
+},
+
+_renderStep4Sell(shards, doubles, triples) {
+  const r = this._state.roster;
+  // Warband size for income table: exclude hired swords and dramatis personae
+  const regularMembers = RosterModel.getMemberCount(r) - (r.hiredSwords || []).length;
+  const capped = Math.min(Math.max(regularMembers, 3), 15);
+  const postgameData = DataService._postgameData;
+  const incomeRow = postgameData?.incomeTable?.find(row => row.warband === capped)
+    || postgameData?.incomeTable?.[postgameData.incomeTable.length - 1];
+  const gcPerShard = incomeRow ? Math.round(incomeRow.gc / capped) : 2;
+
+  this._setBody(`
+    <p>Found <strong>${shards} wyrdstone shard${shards !== 1 ? 's' : ''}</strong>.</p>
+    ${doubles.length || triples.length ? `<p class="text-dim">Exploration results:
+      ${triples.length ? `Triples on <strong>${triples.join(', ')}</strong>` : ''}
+      ${doubles.length ? `Doubles on <strong>${doubles.join(', ')}</strong>` : ''}
+      — resolve these on the Exploration chart.</p>` : ''}
+    <hr style="margin:0.75rem 0; border-color:var(--border);">
+    <p><strong>Sell Wyrdstone</strong></p>
+    <p>Warband has ${regularMembers} members (excl. hired swords). Income rate: <strong>${gcPerShard} gc/shard</strong>.</p>
+    <label>Shards to sell:
+      <input type="number" id="sell-shards-input" value="${shards}" min="0" max="${r.wyrdstone}"
+        style="width:60px; margin-left:0.25rem;">
+      of ${r.wyrdstone} held
+    </label>
+  `);
+
+  this._setFooter(`
+    <button class="btn btn-secondary" onclick="PostgameWizard._renderStep(3)">&lsaquo; Back</button>
+    <button class="btn btn-secondary" onclick="PostgameWizard._renderStep(5)">Skip selling &rsaquo;</button>
+    <button class="btn btn-primary" onclick="PostgameWizard._confirmSell(${gcPerShard})">Sell &amp; Next &rsaquo;</button>
+  `);
+},
+
+_confirmSell(gcPerShard) {
+  const r = this._state.roster;
+  const input = document.getElementById('sell-shards-input');
+  const toSell = Math.min(parseInt(input?.value) || 0, r.wyrdstone);
+  if (toSell <= 0) { this._renderStep(5); return; }
+
+  const gc = toSell * gcPerShard;
+  this._pushUndo();
+  r.wyrdstone -= toSell;
+  r.gold += gc;
+  r.treasuryLog = r.treasuryLog || [];
+  r.treasuryLog.push({
+    id: Storage.generateId(),
+    type: 'income',
+    description: `Sold ${toSell} wyrdstone shard${toSell !== 1 ? 's' : ''} (${gcPerShard} gc each)`,
+    gold: gc,
+    wyrdstone: -toSell,
+    applied: true,
+    date: new Date().toISOString(),
+    actualGoldDelta: gc,
+    actualWyrdstoneDelta: -toSell,
+  });
+  Storage.saveRoster(r);
+  UI.renderRosterEditor();
+  UI.playCoinSound();
+  this._renderStep(5);
+},
+```
+
+- [ ] **Step 2: Load `postgame.json` in `DataService.loadAll()`**
+
+In `js/data.js`, add `postgame.json` to the parallel fetch block:
+
+```js
+const [equipment, skills, magic, hiredSwords, maxStats, injuries, advancement, specialRules, postgame, ...rawWarbandFiles] =
+  await Promise.all([
+    this.fetchJSON('data/equipment.json?' + v),
+    this.fetchJSON('data/skills.json?' + v),
+    this.fetchJSON('data/magic.json?' + v),
+    this.fetchJSON('data/hiredSwords.json?' + v),
+    this.fetchJSON('data/maxStats.json?' + v),
+    this.fetchJSON('data/injuries.json?' + v),
+    this.fetchJSON('data/advancement.json?' + v),
+    this.fetchJSON('data/special_rules.json?' + v),
+    this.fetchJSON('data/postgame.json?' + v),
+    ...indexData.map(...),
+  ]);
+```
+
+And after `this.specialRules = specialRules.specialRules;` add:
+```js
+this._postgameData = postgame;
+```
+
+Also add `_postgameData: null,` to the top of `DataService`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add js/postgame.js js/data.js
+git commit -m "feat: postgame step 4 — exploration dice, wyrdstone shards, and sell income"
+```
+
+---
+
+## Task 7: Steps 5–7 (Hired Swords upkeep, Henchmen availability, Trading Post)
+
+**Files:**
+- Modify: `js/postgame.js`
+
+Step 5: List each hired sword with their upkeep cost (same as `warrior.cost`). Player ticks "Pay" or "Drop". Dropping uses `r.hiredSwords.splice()` (wrapped in `_pushUndo()` so it is undoable). Paying deducts cost from `r.gold` and adds treasury entry.
+
+Step 6: Offer to roll on the henchmen availability table (2D6) from `postgame.json`. Show result row. Player can reroll. No automatic roster mutation — this is informational.
+
+Step 7: Offer to roll on trading post table (2D6) from `postgame.json`. Show item and cost. Player can reroll. This is informational only.
+
+- [ ] **Step 1: Add `_renderStep5()` through `_renderStep7()`**
+
+Add inside `PostgameWizard` after Step 4 methods:
+
+```js
+// ── Step 5: Hired Sword Upkeep ────────────────────────────────────────────
+
+_renderStep5() {
+  const r = this._state.roster;
+  const hs = r.hiredSwords || [];
+  if (hs.length === 0) {
+    this._setBody('<p>No hired swords to pay upkeep for.</p>');
+    this._setFooter(`
+      <button class="btn btn-secondary" onclick="PostgameWizard._renderStep(4)">&lsaquo; Back</button>
+      <button class="btn btn-primary" onclick="PostgameWizard._renderStep(6)">Next &rsaquo;</button>
+    `);
+    return;
+  }
+  this._state._hsDecisions = this._state._hsDecisions || hs.map(() => 'pay');
+
+  this._setBody(`
+    <p>Pay upkeep for your hired swords or dismiss them.</p>
+    <ul class="postgame-warrior-list">
+      ${hs.map((h, i) => `
+        <li class="postgame-warrior-item">
+          <strong style="flex:1">${UI.esc(h.name)}</strong>
+          <span class="text-dim" style="margin-right:0.75rem;">${h.cost} gc</span>
+          <select onchange="PostgameWizard._setHsDecision(${i}, this.value)" class="form-control" style="width:auto;">
+            <option value="pay" ${this._state._hsDecisions[i] === 'pay' ? 'selected' : ''}>Pay upkeep</option>
+            <option value="drop" ${this._state._hsDecisions[i] === 'drop' ? 'selected' : ''}>Dismiss</option>
+          </select>
+        </li>
+      `).join('')}
+    </ul>
+  `);
+  this._setFooter(`
+    <button class="btn btn-secondary" onclick="PostgameWizard._renderStep(4)">&lsaquo; Back</button>
+    <button class="btn btn-primary" onclick="PostgameWizard._confirmStep5()">Apply &amp; Next &rsaquo;</button>
+  `);
+},
+
+_setHsDecision(i, val) {
+  this._state._hsDecisions[i] = val;
+},
+
+_confirmStep5() {
+  const r = this._state.roster;
+  const hs = [...(r.hiredSwords || [])];
+  const decisions = this._state._hsDecisions || [];
+  this._pushUndo();
+
+  const toDrop = [];
+  for (let i = 0; i < hs.length; i++) {
+    if (decisions[i] === 'drop') {
+      toDrop.push(hs[i]);
+    } else {
+      const upkeep = hs[i].cost || 0;
+      if (upkeep > 0) {
+        r.gold = Math.max(0, r.gold - upkeep);
+        r.treasuryLog = r.treasuryLog || [];
+        r.treasuryLog.push({
+          id: Storage.generateId(),
+          type: 'purchase',
+          description: `Upkeep: ${hs[i].name}`,
+          gold: -upkeep,
+          wyrdstone: 0,
+          applied: true,
+          date: new Date().toISOString(),
+          actualGoldDelta: -Math.min(upkeep, r.gold + upkeep), // clamped
+          actualWyrdstoneDelta: 0,
+        });
+      }
+    }
+  }
+  for (const w of toDrop) {
+    const idx = r.hiredSwords.indexOf(w);
+    if (idx !== -1) r.hiredSwords.splice(idx, 1);
+    UI.toast(`${w.name} dismissed.`, 'info');
+  }
+  Storage.saveRoster(r);
+  UI.renderRosterEditor();
+  this._renderStep(6);
+},
+
+// ── Step 6: Henchmen Availability ─────────────────────────────────────────
+
+_renderStep6() {
+  const die = this._state._henchDie;
+  const postgameData = DataService._postgameData;
+  const row = die !== null && die !== undefined
+    ? this._resolveTableRoll(postgameData?.henchmenAvailabilityTable || [], die)
+    : null;
+
+  this._setBody(`
+    <p>Roll 2D6 to see what henchmen are available in the market.</p>
+    <div class="dice-tray" id="hench-dice-tray">
+      <div class="die" onclick="PostgameWizard._rollHenchDice()">${die ?? '?'}</div>
+    </div>
+    ${row ? `<div class="postgame-advancement-result"><strong>Result (${die}):</strong> ${UI.esc(row.result)}</div>` : ''}
+    <p class="text-dim" style="font-size:0.8rem; margin-top:0.75rem;">This step is informational — apply the result manually if you wish.</p>
+  `);
+  this._setFooter(`
+    <button class="btn btn-secondary" onclick="PostgameWizard._renderStep(5)">&lsaquo; Back</button>
+    <button class="btn btn-secondary" onclick="PostgameWizard._rollHenchDice()">&#127922; Roll Again</button>
+    <button class="btn btn-primary" onclick="PostgameWizard._renderStep(7)">Next &rsaquo;</button>
+  `);
+},
+
+_rollHenchDice() {
+  const val = Math.floor(Math.random() * 6) + 1 + Math.floor(Math.random() * 6) + 1;
+  this._state._henchDie = val;
+  this._animateDice('hench-dice-tray', [val], () => this._renderStep6());
+},
+
+// ── Step 7: Trading Post ──────────────────────────────────────────────────
+
+_renderStep7() {
+  const die = this._state._tradeDie;
+  const postgameData = DataService._postgameData;
+  const row = die !== null && die !== undefined
+    ? this._resolveTableRoll(postgameData?.tradingPostTable || [], die)
+    : null;
+
+  this._setBody(`
+    <p>Roll 2D6 to see what item is available at the Trading Post.</p>
+    <div class="dice-tray" id="trade-dice-tray">
+      <div class="die" onclick="PostgameWizard._rollTradeDice()">${die ?? '?'}</div>
+    </div>
+    ${row ? `<div class="postgame-advancement-result"><strong>Result (${die}):</strong> ${UI.esc(row.item)} — ${row.cost} gc</div>` : ''}
+    <p class="text-dim" style="font-size:0.8rem; margin-top:0.75rem;">This step is informational — purchase items manually via the Equipment modal if desired.</p>
+  `);
+  this._setFooter(`
+    <button class="btn btn-secondary" onclick="PostgameWizard._renderStep(6)">&lsaquo; Back</button>
+    <button class="btn btn-secondary" onclick="PostgameWizard._rollTradeDice()">&#127922; Roll Again</button>
+    <button class="btn btn-primary" onclick="PostgameWizard._finishWizard()">Finish &#10003;</button>
+  `);
+},
+
+_rollTradeDice() {
+  const val = Math.floor(Math.random() * 6) + 1 + Math.floor(Math.random() * 6) + 1;
+  this._state._tradeDie = val;
+  this._animateDice('trade-dice-tray', [val], () => this._renderStep7());
+},
+
+_finishWizard() {
+  UI.toast('Post-game sequence complete!', 'success');
+  this.close();
+},
+
+// ── Shared helpers ────────────────────────────────────────────────────────
+
+_resolveTableRoll(table, total) {
+  for (const row of table) {
+    const range = row.roll.toString();
+    if (range.includes('-')) {
+      const [lo, hi] = range.split('-').map(Number);
+      if (total >= lo && total <= hi) return row;
+    } else if (parseInt(range) === total) {
+      return row;
+    }
+  }
+  return null;
+},
+```
+
+- [ ] **Step 2: Verify Steps 5–7 manually**
+
+Walk through the full wizard end-to-end. Verify:
+- Step 5: hired swords listed with cost, drop decision removes from roster, pay deducts gold + logs treasury
+- Step 6: roll shows availability result, reroll works
+- Step 7: roll shows trading post item, "Finish" closes modal and toasts
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add js/postgame.js
+git commit -m "feat: postgame steps 5-7 — hired sword upkeep, henchmen, trading post"
+```
+
+---
+
+## Task 8: Dead-warrior handling in `roster.js` and `ui.js`
+
+**Files:**
+- Modify: `js/roster.js`
+- Modify: `js/ui.js`
+
+Dead heroes/hired swords carry `isDead: true`. They must be excluded everywhere a live warrior is assumed.
+
+- [ ] **Step 1: Exclude dead warriors from `_heroLike()` counts in `roster.js`**
+
+`_heroLike()` is used by `calculateWarbandRating`, `calculateTotalCost`, and `getMemberCount`. Filter dead warriors out:
+
+```js
+_heroLike(roster) {
+  return [
+    ...(roster.heroes       || []).filter(w => !w.isDead),
+    ...(roster.hiredSwords  || []).filter(w => !w.isDead),
+    ...(roster.customWarriors|| []).filter(w => !w.isDead),
+  ];
+},
+```
+
+- [ ] **Step 2: Exclude dead heroes from hero cap check in `ui.js`**
+
+Find the hero cap validation (used before adding a new hero and before `promoteHenchmanToHero`). Change the count to exclude dead heroes:
+
+```js
+// Before:
+const heroCount = roster.heroes.length + (roster.hiredSwords?.length || 0);
+// After:
+const heroCount = roster.heroes.filter(h => !h.isDead).length
+                + (roster.hiredSwords?.filter(h => !h.isDead).length || 0);
+```
+
+- [ ] **Step 3: Render dead heroes greyed-out in `renderWarriorCard()`**
+
+In `renderWarriorCard()`, add a dead-state variant when `warrior.isDead`:
+
+```js
+if (warrior.isDead) {
+  return `<div class="warrior-card warrior-card--dead" data-list-type="${listType}" data-index="${index}">
+    <div class="warrior-card-header" style="opacity:0.45;">
+      <span class="warrior-name" style="text-decoration:line-through;">${UI.esc(warrior.name)}</span>
+      <span class="text-dim" style="font-size:0.75rem; margin-left:0.5rem;">☠ Dead</span>
+    </div>
+    <div style="padding:0.4rem 0.75rem;">
+      <button class="btn btn-sm btn-danger" onclick="UI.removeWarrior('${listType}', ${index})">Remove from roster</button>
+    </div>
+  </div>`;
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add js/roster.js js/ui.js
+git commit -m "feat: dead heroes greyed out, excluded from cap and counts"
+```
+
+---
+
+## Task 9: Entry point, Pro gate, and cache busting
+
+**Files:**
+- Modify: `js/ui.js`
+- Modify: `index.html`
+
+- [ ] **Step 1: Add `openPostgameWizard()` to `UI` in `js/ui.js`**
+
+Find the `// === PROGRESS TAB ===` section and add just before `renderProgressTab()`:
+
+```js
+openPostgameWizard() {
+  if (typeof Cloud !== 'undefined' && !Cloud.canAccess('postgame_sequence')) {
+    this.toast('Post-Game Sequence requires Pro tier.', 'warning');
+    this.showTierOverview();
+    return;
+  }
+  PostgameWizard.open(this.currentRoster);
+},
+```
+
+- [ ] **Step 2: Update the "Start Post-Game Sequence" button visibility in `renderProgressTab()`**
+
+In `renderProgressTab()`, after fetching the `canBattleLog` variable, add:
+
+```js
+const canPostgame = (typeof Cloud !== 'undefined') ? Cloud.canAccess('postgame_sequence') : false;
+const pgBtn = document.getElementById('btn-start-postgame');
+if (pgBtn) {
+  pgBtn.style.display = '';
+  if (!canPostgame) {
+    pgBtn.innerHTML = '&#128274; Post-Game Sequence <span style="font-size:0.75rem;">(Pro)</span>';
+  } else {
+    pgBtn.innerHTML = '&#9876; Start Post-Game Sequence';
+  }
+}
+```
+
+- [ ] **Step 3: Bump cache versions in `index.html`**
+
+Change:
+- `js/data.js?v=15` → `js/data.js?v=16`
+- `js/ui.js?v=41` → `js/ui.js?v=42`
+- `js/postgame.js?v=1` (already set in Task 2)
+
+- [ ] **Step 4: Bump `const v = 'v=13'` in `js/data.js` to `v=14`**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add js/ui.js js/data.js index.html
+git commit -m "feat: wire up postgame wizard entry point with Pro tier gate and cache bump"
+```
+
+---
+
+## Task 9: Final review and PR
+
+- [ ] **Step 1: Full end-to-end walkthrough**
+
+1. Start wizard with no OOA warriors → Steps 2 and 3 skip gracefully
+2. Check 1 hero OOA → injury roll fires, result applied, warrior card updates
+3. Hero with enough XP → advancement roll fires, stat or skill applied
+4. Exploration: roll dice, lock some, reroll unlocked, confirm → wyrdstone added, sell prompt
+5. Hired sword: pay → gold deducted, treasury entry added
+6. Hired sword: drop → removed from roster, undo available
+7. Trading post and henchmen rolls resolve correctly
+8. Non-Pro user: button shows lock icon, clicking opens tier overview
+
+- [ ] **Step 2: Open PR**
+
+```bash
+git push origin feature/postgame-sequence
+gh pr create --title "feat: post-game sequence wizard (Pro)" \
+  --body "Closes #83"
+```

--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
   <title>Mordheim Roster Manager</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/style.css?v=13">
+  <link href="https://fonts.googleapis.com/css2?family=Alegreya:ital,wght@0,400;0,700;1,400&family=Pirata+One&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css?v=14">
   <script>
     // Apply theme before paint to prevent flash
     (function() {

--- a/postgame-mockup.html
+++ b/postgame-mockup.html
@@ -1,0 +1,1102 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Post-Game Sequence — UI Mockup</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg-darkest: #f5f0e8;
+  --bg-dark: #ece5d8;
+  --bg-card: #ffffff;
+  --bg-card-hover: #faf7f2;
+  --bg-input: #f8f5ef;
+  --border: #d4cabb;
+  --border-hover: #b8a98e;
+  --accent: #7f6110;
+  --accent-hover: #8f6c14;
+  --danger: #b33a3a;
+  --success: #2d7a2d;
+  --text: #3d3529;
+  --text-dim: #6b6052;
+  --text-bright: #2a231a;
+  --radius: 6px;
+  --font-display: 'Cinzel', serif;
+}
+[data-theme="dark"] {
+  --bg-darkest: #1a1816;
+  --bg-dark: #242220;
+  --bg-card: #2e2b28;
+  --bg-card-hover: #36332f;
+  --bg-input: #242220;
+  --border: #3d3a36;
+  --border-hover: #5a5550;
+  --accent: #c9a033;
+  --accent-hover: #d4ab3d;
+  --danger: #d04444;
+  --success: #3da63d;
+  --text: #e0dbd3;
+  --text-dim: #a39a8e;
+  --text-bright: #f0ebe5;
+}
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  background: var(--bg-darkest);
+  color: var(--text);
+  font-size: 15px;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem 1rem;
+  gap: 1.5rem;
+}
+
+/* ── Controls bar ── */
+.controls {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: center;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.6rem 1rem;
+}
+.controls label { font-size: 0.8rem; color: var(--text-dim); }
+.controls select, .controls button {
+  font-size: 0.8rem;
+  padding: 0.3rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-input);
+  color: var(--text);
+  cursor: pointer;
+}
+
+/* ── Buttons ── */
+.btn {
+  display: inline-flex; align-items: center; gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+  color: var(--text);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+  white-space: nowrap;
+}
+.btn:hover { background: var(--bg-card-hover); border-color: var(--border-hover); }
+.btn-primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+.btn-primary:hover { background: var(--accent-hover); border-color: var(--accent-hover); }
+.btn-secondary { background: var(--bg-card); border-color: var(--border); color: var(--text); }
+.btn-danger { border-color: var(--danger); color: var(--danger); background: transparent; }
+.btn-danger:hover { background: var(--danger); color: #fff; }
+.btn-sm { padding: 0.3rem 0.6rem; font-size: 0.78rem; }
+
+/* ── Modal shell ── */
+.modal-backdrop {
+  position: relative;
+  width: min(96vw, 660px);
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 8px 40px rgba(0,0,0,0.18);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* ── Header ── */
+.pgw-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem 0.8rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-card);
+}
+.pgw-title {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  color: var(--text-bright);
+  letter-spacing: 0.02em;
+}
+.close-btn {
+  width: 28px; height: 28px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text-dim);
+  font-size: 1rem;
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: all 0.15s;
+}
+.close-btn:hover { background: var(--danger); border-color: var(--danger); color: #fff; }
+
+/* ── Progress bar ── */
+.pgw-progress {
+  display: flex;
+  background: var(--bg-dark);
+  border-bottom: 1px solid var(--border);
+  padding: 0;
+  overflow-x: auto;
+}
+.pgw-step {
+  flex: 1;
+  min-width: 70px;
+  text-align: center;
+  font-size: 0.62rem;
+  color: var(--text-dim);
+  padding: 0.45rem 0.25rem 0.55rem;
+  position: relative;
+  letter-spacing: 0.01em;
+  border-bottom: 3px solid transparent;
+  transition: all 0.2s;
+  cursor: pointer;
+  user-select: none;
+}
+.pgw-step:hover { color: var(--accent); }
+.pgw-step.done { color: var(--accent); border-bottom-color: var(--accent); opacity: 0.6; }
+.pgw-step.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+  font-weight: 700;
+}
+
+/* ── Body ── */
+.pgw-body {
+  padding: 1.25rem;
+  min-height: 260px;
+  overflow-y: auto;
+}
+.pgw-body p { line-height: 1.55; margin-bottom: 0.6rem; }
+.pgw-body h3 { font-size: 0.9rem; font-weight: 600; margin-bottom: 0.5rem; color: var(--text-bright); }
+
+/* ── Footer ── */
+.pgw-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  border-top: 1px solid var(--border);
+  background: var(--bg-dark);
+}
+
+/* ── Warrior checklist ── */
+.warrior-list { list-style: none; padding: 0; margin: 0.5rem 0; }
+.warrior-item {
+  display: flex; align-items: center; gap: 0.75rem;
+  padding: 0.5rem 0.25rem;
+  border-bottom: 1px solid var(--border);
+  transition: background 0.1s;
+}
+.warrior-item:last-child { border-bottom: none; }
+.warrior-item:hover { background: var(--bg-card-hover); }
+.warrior-item input[type=checkbox] { width: 16px; height: 16px; cursor: pointer; accent-color: var(--accent); }
+.warrior-item label { flex: 1; cursor: pointer; font-size: 0.9rem; }
+.warrior-section-header {
+  padding: 0.35rem 0.25rem 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-dim);
+  border-bottom: 1px solid var(--border);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  margin-top: 0.25rem;
+}
+.warrior-item--indent {
+  padding-left: 1.5rem;
+  background: var(--bg-dark);
+}
+.warrior-item--indent:last-of-type { border-bottom: 1px solid var(--border); }
+.warrior-item .xp-badge {
+  font-size: 0.7rem;
+  background: var(--bg-dark);
+  border: 1px solid var(--border);
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  color: var(--text-dim);
+}
+
+/* ── Dice tray ── */
+.dice-tray {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  margin: 1rem 0 0.5rem;
+}
+.die {
+  width: 62px; height: 62px;
+  border: 2px solid var(--accent);
+  border-radius: 12px;
+  display: grid;
+  grid-template: repeat(3, 1fr) / repeat(3, 1fr);
+  padding: 9px;
+  gap: 3px;
+  background: var(--bg-card);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12), inset 0 1px 0 rgba(255,255,255,0.08);
+  cursor: default;
+  user-select: none;
+  transition: transform 0.15s, box-shadow 0.15s;
+  position: relative;
+}
+.die.lockable:hover { transform: scale(1.08); box-shadow: 0 4px 14px rgba(0,0,0,0.2); cursor: pointer; }
+.die.rolling { animation: diceRoll 0.45s ease-out; }
+.die.locked { border-color: var(--success); }
+.die.blank {
+  border-style: dashed;
+  border-color: var(--border);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  font-style: italic;
+  font-family: Georgia, serif;
+}
+.pip {
+  border-radius: 50%;
+  background: var(--accent);
+  width: 100%;
+  height: 100%;
+  grid-column: var(--col);
+  grid-row: var(--row);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.25);
+}
+[data-theme="dark"] .pip { background: var(--accent); }
+
+/* ── Injury step two-column layout ── */
+.injury-layout {
+  display: grid;
+  grid-template-columns: 1fr 180px;
+  gap: 1rem;
+  align-items: start;
+}
+.injury-main {}
+.injury-sidebar {
+  border-left: 1px solid var(--border);
+  padding-left: 0.9rem;
+}
+.injury-sidebar-title {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+  margin-bottom: 0.5rem;
+}
+.injury-warrior-row {
+  display: flex;
+  flex-direction: column;
+  padding: 0.35rem 0.5rem;
+  border-radius: var(--radius);
+  margin-bottom: 0.2rem;
+  font-size: 0.82rem;
+  color: var(--text-dim);
+  line-height: 1.3;
+}
+.injury-warrior-row.active {
+  background: var(--accent);
+  color: #fff;
+}
+.injury-warrior-row .warrior-subtype {
+  font-size: 0.7rem;
+  opacity: 0.75;
+}
+.injury-warrior-row.done {
+  opacity: 0.45;
+}
+.injury-warrior-row.dead {
+  text-decoration: line-through;
+  opacity: 0.35;
+  color: var(--danger);
+}
+
+/* ── Cursive subtitle ── */
+.injury-subtitle {
+  font-style: italic;
+  font-family: Georgia, 'Times New Roman', serif;
+  color: var(--text-dim);
+  font-size: 0.88rem;
+  margin-bottom: 0.75rem;
+}
+
+/* ── Injury result name + description ── */
+.injury-result-name {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-bright);
+}
+.injury-result-name.danger { color: var(--danger); }
+.injury-result-name.success { color: var(--success); }
+.injury-result-desc {
+  font-style: italic;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 0.82rem;
+  color: var(--text-dim);
+  margin-top: 0.2rem;
+}
+@keyframes diceRoll {
+  0%   { transform: rotate(0deg) scale(1); }
+  25%  { transform: rotate(-18deg) scale(1.12); }
+  50%  { transform: rotate(14deg) scale(0.94); }
+  75%  { transform: rotate(-9deg) scale(1.06); }
+  100% { transform: rotate(0deg) scale(1); }
+}
+.die-hint { text-align: center; font-size: 0.75rem; color: var(--text-dim); margin-top: 0.25rem; }
+
+/* ── Result box ── */
+.result-box {
+  background: var(--bg-dark);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius);
+  padding: 0.75rem 1rem;
+  margin: 0.75rem 0;
+}
+.result-box.danger { border-left-color: var(--danger); }
+.result-box.success { border-left-color: var(--success); }
+.result-box strong { display: block; margin-bottom: 0.2rem; font-size: 0.95rem; }
+.result-box p { font-size: 0.82rem; color: var(--text-dim); margin: 0; }
+
+/* ── Skill picker ── */
+.skill-picker { margin-top: 0.75rem; }
+.skill-picker label { font-size: 0.82rem; color: var(--text-dim); display: block; margin-bottom: 0.3rem; }
+.skill-picker select {
+  width: 100%;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-input);
+  color: var(--text);
+  font-size: 0.85rem;
+}
+
+/* ── Exploration ── */
+.explore-controls {
+  display: flex; gap: 1.5rem; align-items: center; flex-wrap: wrap;
+  background: var(--bg-dark);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.65rem 0.9rem;
+  margin-bottom: 0.5rem;
+  font-size: 0.85rem;
+}
+.explore-controls label { display: flex; align-items: center; gap: 0.35rem; cursor: pointer; }
+.explore-controls input[type=checkbox] { accent-color: var(--accent); }
+.explore-controls input[type=number] {
+  width: 52px; padding: 0.2rem 0.4rem;
+  border: 1px solid var(--border); border-radius: var(--radius);
+  background: var(--bg-input); color: var(--text); font-size: 0.85rem;
+}
+.doubles-badge {
+  display: inline-flex; align-items: center; gap: 0.3rem;
+  background: var(--accent); color: #fff;
+  font-size: 0.75rem; font-weight: 600;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  margin-left: 0.4rem;
+}
+
+/* ── HS Upkeep ── */
+.hs-row {
+  display: flex; align-items: center; gap: 0.75rem;
+  padding: 0.55rem 0.25rem;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.88rem;
+}
+.hs-row:last-child { border-bottom: none; }
+.hs-row .hs-name { flex: 1; font-weight: 600; }
+.hs-row .hs-cost { color: var(--text-dim); }
+.hs-row select {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--border); border-radius: var(--radius);
+  background: var(--bg-input); color: var(--text); font-size: 0.82rem;
+}
+
+/* ── Text utility ── */
+.text-dim { color: var(--text-dim); }
+.text-sm { font-size: 0.82rem; }
+hr { border: none; border-top: 1px solid var(--border); margin: 0.75rem 0; }
+.form-row { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.5rem; font-size: 0.88rem; }
+.form-row input[type=number] {
+  width: 64px; padding: 0.3rem 0.5rem;
+  border: 1px solid var(--border); border-radius: var(--radius);
+  background: var(--bg-input); color: var(--text); font-size: 0.88rem;
+}
+.step-label { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.75rem; }
+.step-num {
+  width: 24px; height: 24px;
+  border-radius: 50%; background: var(--accent); color: #fff;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 0.75rem; font-weight: 700; flex-shrink: 0;
+}
+</style>
+</head>
+<body>
+
+<!-- Controls -->
+<div class="controls">
+  <label>Theme:</label>
+  <select onchange="document.documentElement.dataset.theme = this.value">
+    <option value="light">Light (Parchment)</option>
+    <option value="dark">Dark</option>
+  </select>
+  <label>Step:</label>
+  <select onchange="showStep(this.value)">
+    <option value="1">Step 1 — Out of Action</option>
+    <option value="2">Step 2 — Injuries</option>
+    <option value="2b">Step 2b — Injury Result (Dead)</option>
+    <option value="2c">Step 2c — Injury Result (Full Recovery)</option>
+    <option value="3">Step 3 — Advancements</option>
+    <option value="3b">Step 3b — New Skill Result</option>
+    <option value="4">Step 4 — Exploration</option>
+    <option value="4b">Step 4b — Sell Wyrdstone</option>
+    <option value="5">Step 5 — Hired Swords</option>
+    <option value="6">Step 6 — Henchmen Availability</option>
+    <option value="7">Step 7 — Trading Post</option>
+  </select>
+  <button onclick="rollAllDice()">🎲 Roll demo dice</button>
+</div>
+
+<!-- Modal -->
+<div class="modal-backdrop" id="modal">
+
+  <!-- Header -->
+  <div class="pgw-header">
+    <span class="pgw-title">Post-Game Sequence</span>
+    <button class="close-btn">&times;</button>
+  </div>
+
+  <!-- Progress bar -->
+  <div class="pgw-progress" id="progress-bar">
+    <div class="pgw-step done"  onclick="showStep('1')">1. Out of Action</div>
+    <div class="pgw-step active" onclick="showStep('2')">2. Injuries</div>
+    <div class="pgw-step"        onclick="showStep('3')">3. Advancements</div>
+    <div class="pgw-step"        onclick="showStep('4')">4. Exploration</div>
+    <div class="pgw-step"        onclick="showStep('5')">5. Hired Swords</div>
+    <div class="pgw-step"        onclick="showStep('6')">6. Henchmen</div>
+    <div class="pgw-step"        onclick="showStep('7')">7. Trading Post</div>
+  </div>
+
+  <!-- Body -->
+  <div class="pgw-body" id="body"></div>
+
+  <!-- Footer -->
+  <div class="pgw-footer" id="footer"></div>
+
+</div>
+
+<script>
+// ── Dice pip helpers (must be defined before STEPS) ──────────────────────
+const PIP_POSITIONS_EARLY = {
+  1:[[2,2]], 2:[[3,1],[1,3]], 3:[[3,1],[2,2],[1,3]],
+  4:[[1,1],[3,1],[1,3],[3,3]], 5:[[1,1],[3,1],[2,2],[1,3],[3,3]],
+  6:[[1,1],[1,2],[1,3],[3,1],[3,2],[3,3]],
+};
+function _pips(val) {
+  return (PIP_POSITIONS_EARLY[val]||[]).map(([c,r])=>`<span class="pip" style="--col:${c};--row:${r}"></span>`).join('');
+}
+
+const STEPS = {
+  1: {
+    label: 'Out of Action',
+    body: `
+      <div class="step-label"><div class="step-num">1</div><h3>Who was taken out of action?</h3></div>
+      <p class="text-dim text-sm">Check any warrior who was taken out of action this battle. Henchmen groups are listed per model.</p>
+      <ul class="warrior-list">
+        <li class="warrior-item"><input type="checkbox" id="ooa0" checked><label for="ooa0">Karl Hammerfist <span class="text-dim">(Captain)</span></label><span class="xp-badge">23 XP</span></li>
+        <li class="warrior-item"><input type="checkbox" id="ooa1"><label for="ooa1">Greta the Bold <span class="text-dim">(Champion)</span></label><span class="xp-badge">11 XP</span></li>
+        <li class="warrior-item"><input type="checkbox" id="ooa2" checked><label for="ooa2">Brother Alric <span class="text-dim">(Priest of Sigmar)</span></label><span class="xp-badge">6 XP</span></li>
+        <li class="warrior-section-header">Swordsmen <span class="text-dim">(Henchmen group · 5 XP)</span></li>
+        <li class="warrior-item warrior-item--indent"><input type="checkbox" id="ooa3a" checked><label for="ooa3a">Swordsman #1</label></li>
+        <li class="warrior-item warrior-item--indent"><input type="checkbox" id="ooa3b"><label for="ooa3b">Swordsman #2</label></li>
+        <li class="warrior-item warrior-item--indent"><input type="checkbox" id="ooa3c"><label for="ooa3c">Swordsman #3</label></li>
+        <li class="warrior-item"><input type="checkbox" id="ooa4"><label for="ooa4">Tilean Marksman <span class="text-dim">(Hired Sword)</span></label><span class="xp-badge">0 XP</span></li>
+      </ul>
+    `,
+    footer: `
+      <button class="btn btn-secondary">Cancel</button>
+      <button class="btn btn-primary" onclick="showStep(2)">Next ›</button>
+    `,
+    active: 1,
+  },
+
+  2: 'dynamic',  // rendered by renderInjuryStep()
+
+  3: {
+    label: 'Advancements',
+    body: `
+      <div class="step-label"><div class="step-num">3</div><h3>Advancement Roll — Greta the Bold</h3></div>
+      <p class="text-dim text-sm">Greta has reached a new experience threshold (11 XP → Level 3). Roll 2D6 on the hero advancement table.</p>
+      <div class="dice-tray">
+        <div class="die blank" id="d1">?</div>
+        <div class="die blank" id="d2">?</div>
+      </div>
+      <p class="die-hint">Click a die to reroll it individually.</p>
+      <p class="text-dim text-sm" style="text-align:center; margin-top:0.5rem;">1 of 1 warrior eligible</p>
+    `,
+    footer: `
+      <button class="btn btn-secondary" onclick="showStep(2)">‹ Back</button>
+      <button class="btn btn-secondary" onclick="rollAllDice()">🎲 Roll All</button>
+    `,
+    active: 3,
+  },
+
+  '3b': {
+    label: 'Advancements',
+    body: `
+      <div class="step-label"><div class="step-num">3</div><h3>Advancement Roll — Greta the Bold</h3></div>
+      <p class="text-dim text-sm">Greta has reached a new experience threshold (11 XP → Level 3). Roll 2D6 on the hero advancement table.</p>
+      <div class="dice-tray">
+        <div class="die" id="d1">1</div>
+        <div class="die" id="d2">2</div>
+      </div>
+      <p class="die-hint">Click a die to reroll it individually.</p>
+      <div class="result-box">
+        <strong>🏅 New Skill (roll: 2–4)</strong>
+        <p>Choose a new skill from Greta's available skill categories.</p>
+        <div class="skill-picker">
+          <label>Select skill to learn:</label>
+          <select>
+            <optgroup label="Combat Skills">
+              <option>Dodge</option>
+              <option>Step Aside</option>
+              <option>Counter Attack</option>
+            </optgroup>
+            <optgroup label="Strength Skills">
+              <option>Mighty Blow</option>
+              <option>Pit Fighter</option>
+              <option>Resilient</option>
+            </optgroup>
+          </select>
+        </div>
+      </div>
+    `,
+    footer: `
+      <button class="btn btn-secondary" onclick="showStep(2)">‹ Back</button>
+      <button class="btn btn-secondary" onclick="showStep(3)">🎲 Reroll</button>
+      <button class="btn btn-primary" onclick="showStep(4)">Apply & Next ›</button>
+    `,
+    active: 3,
+  },
+
+  4: {
+    label: 'Exploration',
+    body: `
+      <div class="step-label"><div class="step-num">4</div><h3>Exploration Dice</h3></div>
+      <p class="text-dim text-sm">Active heroes (not OOA) each contribute 1 exploration die. You have <strong>2 active heroes</strong>.</p>
+      <div class="explore-controls">
+        <label><input type="checkbox" id="won"> Won the scenario (+1 die)</label>
+        <label>Extra dice: <input type="number" value="0" min="0" max="10" id="extra-dice" oninput="updateDiceCount()"></label>
+        <span class="text-dim text-sm">Total: <strong id="dice-total">2</strong> dice</span>
+      </div>
+      <div class="dice-tray" id="explore-tray">
+        <div class="die blank lockable">?</div>
+        <div class="die blank lockable">?</div>
+      </div>
+      <p class="die-hint">After rolling — click a die to <strong>lock</strong> it (green border = locked). Locked dice won't be rerolled.</p>
+    `,
+    footer: `
+      <button class="btn btn-secondary" onclick="showStep(3)">‹ Back</button>
+      <button class="btn btn-secondary" onclick="rollExploreDice()">🎲 Roll Unlocked</button>
+    `,
+    active: 4,
+  },
+
+  '4b': {
+    label: 'Exploration',
+    body: `
+      <div class="step-label"><div class="step-num">4</div><h3>Exploration Result</h3></div>
+      <div class="dice-tray">
+        <div class="die">4</div>
+        <div class="die">4</div>
+        <div class="die locked">2</div>
+        <div class="die">4</div>
+      </div>
+      <div class="result-box success">
+        <strong>Found 14 wyrdstone shards · <span class="doubles-badge">Doubles: 4</span></strong>
+        <p>Resolve doubles on the Exploration chart. Wyrdstone added to your stockpile.</p>
+      </div>
+      <hr>
+      <h3>Sell Wyrdstone</h3>
+      <p class="text-dim text-sm">Your warband has 8 members (excl. hired swords). Income rate: <strong>10 gc per shard</strong>.</p>
+      <div class="form-row">
+        <label>Shards to sell:</label>
+        <input type="number" value="14" min="0" max="14"> of 14 held
+        <span class="text-dim text-sm">= 140 gc</span>
+      </div>
+    `,
+    footer: `
+      <button class="btn btn-secondary" onclick="showStep(4)">‹ Back</button>
+      <button class="btn btn-secondary" onclick="showStep(5)">Skip selling ›</button>
+      <button class="btn btn-primary" onclick="showStep(5)">Sell & Next ›</button>
+    `,
+    active: 4,
+  },
+
+  5: {
+    label: 'Hired Swords',
+    body: `
+      <div class="step-label"><div class="step-num">5</div><h3>Hired Sword Upkeep</h3></div>
+      <p class="text-dim text-sm">Pay upkeep for your hired swords or dismiss them from service.</p>
+      <div style="margin-top:0.5rem;">
+        <div class="hs-row">
+          <span class="hs-name">Tilean Marksman</span>
+          <span class="hs-cost">15 gc</span>
+          <select><option selected>Pay upkeep</option><option>Dismiss</option></select>
+        </div>
+        <div class="hs-row">
+          <span class="hs-name">Dwarf Troll Slayer</span>
+          <span class="hs-cost">25 gc</span>
+          <select><option>Pay upkeep</option><option selected>Dismiss</option></select>
+        </div>
+      </div>
+      <p class="text-dim text-sm" style="margin-top:0.75rem;">Dismissed hired swords are removed from your roster. This action can be undone with the undo button.</p>
+    `,
+    footer: `
+      <button class="btn btn-secondary" onclick="showStep(4)">‹ Back</button>
+      <button class="btn btn-secondary" style="margin-right:auto;" onclick="alert('Undo last action')">↩ Undo</button>
+      <button class="btn btn-primary" onclick="showStep(6)">Apply & Next ›</button>
+    `,
+    active: 5,
+  },
+
+  6: {
+    label: 'Henchmen',
+    body: `
+      <div class="step-label"><div class="step-num">6</div><h3>Henchmen Availability</h3></div>
+      <p class="text-dim text-sm">Roll 2D6 to see what henchmen are available in the market this week.</p>
+      <div class="dice-tray">
+        <div class="die" id="hd1">${_pips(5)}</div>
+        <div class="die" id="hd2">${_pips(3)}</div>
+      </div>
+      <div class="result-box">
+        <strong>Result (8): D3 henchmen of any type in the warband list</strong>
+        <p>You may recruit up to D3 henchmen of any type available to your warband. Apply manually via the Warriors tab.</p>
+      </div>
+      <p class="text-dim text-sm" style="margin-top:0.5rem;">This step is informational — add henchmen manually via the Warriors tab.</p>
+    `,
+    footer: `
+      <button class="btn btn-secondary" onclick="showStep(5)">‹ Back</button>
+      <button class="btn btn-secondary" onclick="rollHenchDice()">🎲 Roll Again</button>
+      <button class="btn btn-primary" onclick="showStep(7)">Next ›</button>
+    `,
+    active: 6,
+  },
+
+  7: {
+    label: 'Trading Post',
+    body: `
+      <div class="step-label"><div class="step-num">7</div><h3>Trading Post</h3></div>
+      <p class="text-dim text-sm">Roll 2D6 to see what rare item is available at the Trading Post.</p>
+      <div class="dice-tray">
+        <div class="die" id="td1">${_pips(4)}</div>
+        <div class="die" id="td2">${_pips(6)}</div>
+      </div>
+      <div class="result-box">
+        <strong>Result (10): Shield — 5 gc</strong>
+        <p>A Shield is available for purchase. Buy it manually via the Equipment modal if desired.</p>
+      </div>
+      <p class="text-dim text-sm" style="margin-top:0.5rem;">This step is informational — purchase items manually via the Warriors tab.</p>
+    `,
+    footer: `
+      <button class="btn btn-secondary" onclick="showStep(6)">‹ Back</button>
+      <button class="btn btn-secondary" onclick="rollTradeDice()">🎲 Roll Again</button>
+      <button class="btn btn-primary" onclick="alert('Post-game complete! ✔')">Finish ✔</button>
+    `,
+    active: 7,
+  },
+};
+
+// col/row positions (1-3) for each die face value
+const PIP_POSITIONS = {
+  1: [[2,2]],
+  2: [[3,1],[1,3]],
+  3: [[3,1],[2,2],[1,3]],
+  4: [[1,1],[3,1],[1,3],[3,3]],
+  5: [[1,1],[3,1],[2,2],[1,3],[3,3]],
+  6: [[1,1],[1,2],[1,3],[3,1],[3,2],[3,3]],
+};
+
+function dieFaceHTML(val) {
+  const pips = PIP_POSITIONS[val] || [];
+  return pips.map(([col, row]) =>
+    `<span class="pip" style="--col:${col};--row:${row}"></span>`
+  ).join('');
+}
+
+function blankDieHTML(id) {
+  return `<div class="die blank" id="${id}" data-val="">roll</div>`;
+}
+
+function valuedDieHTML(id, val) {
+  return `<div class="die" id="${id}" data-val="${val}">${dieFaceHTML(val)}</div>`;
+}
+
+const HERO_INJURIES = [
+  { range:[11,15], name:'Dead',                    desc:'The warrior is dead. Remove them from the roster and lose all their equipment.',       severity:'danger'  },
+  { range:[16,21], name:'Multiple Injuries',        desc:'Roll D6 more times on this table, applying each result (ignoring further multiples).', severity:'danger'  },
+  { range:[22,22], name:'Leg Wound',                desc:'The warrior suffers a permanent leg injury. Their Movement characteristic is reduced by 1.', severity:'warning' },
+  { range:[23,23], name:'Arm Wound',                desc:'The warrior\'s arm is badly wounded. Their Weapon Skill is permanently reduced by 1.', severity:'warning' },
+  { range:[24,24], name:'Madness',                  desc:'Roll a D6: 1–3 the warrior gains the Stupidity rule; 4–6 the warrior gains the Frenzy rule.',  severity:'warning' },
+  { range:[25,25], name:'Smashed Leg',              desc:'The warrior\'s leg is crushed. They may no longer run, though they may still charge. Movement –1 permanently.', severity:'warning' },
+  { range:[26,26], name:'Chest Wound',              desc:'A grievous wound to the torso leaves the warrior weakened. Toughness is permanently reduced by 1.', severity:'warning' },
+  { range:[31,31], name:'Blinded in One Eye',       desc:'The warrior loses the sight in one eye. Ballistic Skill is permanently reduced by 1.', severity:'warning' },
+  { range:[32,32], name:'Old Battle Wound',         desc:'The wound never fully heals. Before each battle roll a D6: on a 1 the warrior misses that battle.', severity:'warning' },
+  { range:[33,33], name:'Nervous Condition',        desc:'The warrior\'s nerves are shattered. Initiative is permanently reduced by 1.',          severity:'warning' },
+  { range:[34,34], name:'Hand Injury',              desc:'The warrior\'s sword hand is injured. Weapon Skill is permanently reduced by 1.',        severity:'warning' },
+  { range:[35,35], name:'Deep Wound',               desc:'The warrior\'s injuries are serious. They must miss the next battle while recovering.',   severity:'warning' },
+  { range:[36,36], name:'Robbed',                   desc:'While helpless the warrior is stripped of their gear. All equipment is lost.',           severity:'warning' },
+  { range:[41,55], name:'Full Recovery',            desc:'The warrior shakes off their wounds and returns to full fighting strength with no lasting effects.', severity:'success' },
+  { range:[56,56], name:'Bitter Enmity',            desc:'The warrior harbours a deep grudge. They gain the Hatred special rule against the warband that caused the injury.', severity:'warning' },
+  { range:[61,61], name:'Captured',                 desc:'The warrior is taken prisoner. Roll after the game to determine their fate — ransom, rescue, or execution.', severity:'danger'  },
+  { range:[62,63], name:'Hardened',                 desc:'Facing death has steeled the warrior\'s resolve. They become immune to Fear.',            severity:'success' },
+  { range:[64,64], name:'Horrible Scars',           desc:'The warrior\'s wounds leave terrible scarring. They now cause Fear in enemy models.',     severity:'success' },
+  { range:[65,65], name:'Sold to the Pits',         desc:'The warrior is sold to fight in the pit arenas. They return with D6 extra Experience points.', severity:'success' },
+  { range:[66,66], name:'Survives Against the Odds',desc:'Against all expectation the warrior pulls through. Gain +1 Experience.',                  severity:'success' },
+];
+
+// Left die is tens, right die is units: left=3, right=1 → 31
+function toInjuryRoll(d1, d2) {
+  return d1 * 10 + d2;
+}
+
+function resolveHeroInjury(d1, d2) {
+  const roll = toInjuryRoll(d1, d2);
+  return HERO_INJURIES.find(r => roll >= r.range[0] && roll <= r.range[1]) || null;
+}
+
+function updateInjuryResult() {
+  const d1 = document.getElementById('d1');
+  const d2 = document.getElementById('d2');
+  if (!d1 || d1.classList.contains('blank')) return;
+  const v1 = parseInt(d1.dataset.val);
+  const v2 = d2 ? parseInt(d2.dataset.val) : null;
+  if (isNaN(v1) || (d2 && isNaN(v2))) return;
+  const roll = toInjuryRoll(v1, v2);
+  const result = resolveHeroInjury(v1, v2);
+  if (result) showInjuryResult(result.name, result.desc, result.severity, roll);
+}
+
+function rerollDie(id, isHero) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  const val = Math.floor(Math.random() * 6) + 1;
+  el.classList.remove('blank');
+  el.classList.add('rolling');
+  setTimeout(() => {
+    el.textContent = val;
+    el.classList.remove('rolling');
+    updateInjuryResult();
+    // Show Apply button once both dice have values
+    const d1 = document.getElementById('d1');
+    const d2 = document.getElementById('d2');
+    const bothRolled = d1 && !d1.classList.contains('blank') && (!d2 || !d2.classList.contains('blank'));
+    if (bothRolled) {
+      const footer = document.getElementById('footer');
+      if (footer && !footer.innerHTML.includes('Apply')) {
+        footer.innerHTML += `<button class="btn btn-primary" onclick="showStep(3)">Apply & Next ›</button>`;
+      }
+    }
+  }, 500);
+}
+
+// OOA warriors for the mockup (name, type, isHero)
+const OOA_WARRIORS = [
+  { name: 'Karl Hammerfist', type: 'Captain',          isHero: true  },
+  { name: 'Swordsman #1',    type: 'Swordsmen',        isHero: false },
+  { name: 'Brother Alric',   type: 'Priest of Sigmar', isHero: true  },
+  { name: 'Swordsman #2',    type: 'Swordsmen',        isHero: false },
+];
+let injuryIdx = 0;
+const deadWarriorIndices = new Set();
+let lastInjuryResult = null;
+
+function renderInjuryStep() {
+  if (injuryIdx >= OOA_WARRIORS.length) { showStep(3); return; }
+
+  const w = OOA_WARRIORS[injuryIdx];
+  const table = w.isHero ? 'hero injury table (2D6)' : 'henchman injury table (1D6)';
+
+  const sidebar = OOA_WARRIORS.map((warrior, i) => {
+    let cls = 'injury-warrior-row';
+    if (deadWarriorIndices.has(i))  cls += ' dead';
+    else if (i < injuryIdx)         cls += ' done';
+    else if (i === injuryIdx)       cls += ' active';
+    return `<div class="${cls}">
+      <span>${warrior.name}</span>
+      <span class="warrior-subtype">${warrior.type}</span>
+    </div>`;
+  }).join('');
+
+  document.getElementById('body').innerHTML = `
+    <div class="injury-layout">
+      <div class="injury-main">
+        <div class="step-label"><div class="step-num">2</div>
+          <h3>Injury Roll — ${w.name} <span style="font-weight:400;color:var(--text-dim);">(${w.type})</span></h3>
+        </div>
+        <p class="injury-subtitle">${w.name} was taken out of action. Roll on the ${table}.</p>
+        <div class="dice-tray">
+          ${w.isHero ? `
+            <div style="display:flex;flex-direction:column;align-items:center;gap:0.3rem;">
+              ${blankDieHTML('d1')}
+              <span class="text-dim" style="font-size:0.7rem;">tens</span>
+            </div>
+            <div style="display:flex;flex-direction:column;align-items:center;gap:0.3rem;">
+              ${blankDieHTML('d2')}
+              <span class="text-dim" style="font-size:0.7rem;">units</span>
+            </div>
+          ` : `
+            <div style="display:flex;flex-direction:column;align-items:center;gap:0.3rem;">
+              ${blankDieHTML('d1')}
+            </div>
+          `}
+        </div>
+        <div id="injury-result" style="margin-top:0.75rem;min-height:1.8rem;"></div>
+      </div>
+      <div class="injury-sidebar">
+        <div class="injury-sidebar-title">Injury rolls</div>
+        ${sidebar}
+      </div>
+    </div>
+  `;
+
+  document.getElementById('footer').innerHTML = `
+    <button class="btn btn-secondary" onclick="showStep(1)">‹ Back</button>
+    <button class="btn btn-secondary" id="btn-roll-injury" onclick="rollInjuryDice()">🎲 Roll</button>
+  `;
+
+  updateProgressBar(2);
+}
+
+function rollInjuryDice() {
+  const w = OOA_WARRIORS[injuryIdx];
+  const d1 = document.getElementById('d1');
+  const d2 = document.getElementById('d2');
+  const v1 = Math.floor(Math.random() * 6) + 1;
+  const v2 = w.isHero ? Math.floor(Math.random() * 6) + 1 : null;
+
+  [[d1, v1], [d2, v2]].filter(([el]) => el).forEach(([el, val]) => {
+    el.classList.remove('blank');
+    el.innerHTML = '';
+    el.classList.add('rolling');
+    el.dataset.val = val;
+    setTimeout(() => {
+      el.classList.remove('rolling');
+      el.innerHTML = dieFaceHTML(val);
+    }, 450);
+  });
+
+  setTimeout(() => {
+    if (w.isHero) {
+      updateInjuryResult();
+    } else {
+      const res = v1 <= 2 ? 'Dead' : 'Full Recovery';
+      const henchDesc = v1 <= 2
+        ? 'The henchman is slain outright. Remove them from the roster.'
+        : 'The henchman makes a full recovery with no lasting effects.';
+      const severity = v1 <= 2 ? 'danger' : 'success';
+      showInjuryResult(res, henchDesc, severity, v1);
+    }
+
+    const footer = document.getElementById('footer');
+    if (!footer.innerHTML.includes('Apply')) {
+      const nextLabel = injuryIdx + 1 < OOA_WARRIORS.length ? 'Apply & Next ›' : 'Apply & Continue ›';
+      footer.innerHTML += `<button class="btn btn-primary" onclick="applyInjuryAndNext()">${nextLabel}</button>`;
+    }
+  }, 600);
+}
+
+function showInjuryResult(name, desc, severity, roll) {
+  lastInjuryResult = name;
+  const el = document.getElementById('injury-result');
+  if (!el) return;
+  el.innerHTML = `
+    <div class="result-box ${severity === 'danger' ? 'danger' : severity === 'success' ? 'success' : ''}">
+      <div style="display:flex;align-items:baseline;gap:0.5rem;">
+        <span class="injury-result-name ${severity}">${name}</span>
+        <span class="text-dim" style="font-size:0.75rem;">roll: ${roll}</span>
+      </div>
+      <div class="injury-result-desc">${desc}</div>
+    </div>`;
+}
+
+function applyInjuryAndNext() {
+  if (lastInjuryResult === 'Dead') deadWarriorIndices.add(injuryIdx);
+  lastInjuryResult = null;
+  injuryIdx++;
+  renderInjuryStep();
+}
+
+function updateProgressBar(active) {
+  document.querySelectorAll('.pgw-step').forEach((el, i) => {
+    el.className = 'pgw-step';
+    const n = i + 1;
+    if (n < active) el.classList.add('done');
+    if (n === active) el.classList.add('active');
+  });
+}
+
+function showStep(key) {
+  if (key == 2) { renderInjuryStep(); return; }
+
+  // Accept both numeric and string keys (e.g. 2, '2b')
+  const s = STEPS[key] || STEPS[String(key)];
+  if (!s) return;
+  document.getElementById('body').innerHTML = s.body;
+  document.getElementById('footer').innerHTML = s.footer;
+
+  if (key == 1) { injuryIdx = 0; deadWarriorIndices.clear(); lastInjuryResult = null; }
+  updateProgressBar(s.active);
+
+  // Attach lock-toggle for exploration dice only
+  document.querySelectorAll('.die.lockable').forEach(die => {
+    die.style.cursor = 'pointer';
+    die.onclick = () => die.classList.toggle('locked');
+  });
+
+  // Re-sync controls
+  const select = document.querySelector('.controls select:nth-child(4)');
+  if (select) {
+    const opt = [...select.options].find(o => o.value == key);
+    if (opt) select.value = key;
+  }
+}
+
+function rollAllDice() {
+  document.querySelectorAll('.die').forEach(die => {
+    const val = Math.floor(Math.random() * 6) + 1;
+    die.classList.remove('blank');
+    die.innerHTML = '';
+    die.dataset.val = val;
+    die.classList.add('rolling');
+    setTimeout(() => {
+      die.classList.remove('rolling');
+      die.innerHTML = dieFaceHTML(val);
+    }, 500);
+  });
+
+  setTimeout(() => {
+    updateInjuryResult();
+    const footer = document.getElementById('footer');
+    if (footer && !footer.innerHTML.includes('Apply')) {
+      const nextLabel = injuryIdx + 1 < OOA_WARRIORS.length ? 'Apply & Next ›' : 'Apply & Continue ›';
+      footer.innerHTML += `<button class="btn btn-primary" onclick="applyInjuryAndNext()">${nextLabel}</button>`;
+    }
+  }, 600);
+}
+
+function rollExploreDice() {
+  const tray = document.getElementById('explore-tray');
+  if (!tray) return;
+  tray.querySelectorAll('.die').forEach(die => {
+    if (die.classList.contains('locked')) return;
+    const val = Math.floor(Math.random() * 6) + 1;
+    die.classList.remove('blank');
+    die.innerHTML = '';
+    die.classList.add('rolling');
+    die.dataset.val = val;
+    die.onclick = () => die.classList.toggle('locked');
+    setTimeout(() => {
+      die.classList.remove('rolling');
+      die.innerHTML = dieFaceHTML(val);
+    }, 450);
+  });
+  setTimeout(() => {
+    const footer = document.getElementById('footer');
+    if (!footer.innerHTML.includes('Confirm')) {
+      footer.innerHTML += `<button class="btn btn-primary" onclick="showStep('4b')">Confirm Exploration ›</button>`;
+    }
+  }, 600);
+}
+
+function rollTwoDice(id1, id2, onResult) {
+  const v1 = Math.floor(Math.random() * 6) + 1;
+  const v2 = Math.floor(Math.random() * 6) + 1;
+  [id1, id2].forEach(id => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.classList.remove('blank');
+    el.innerHTML = '';
+    el.classList.add('rolling');
+  });
+  setTimeout(() => {
+    [id1, id2].forEach((id, i) => {
+      const el = document.getElementById(id);
+      if (!el) return;
+      el.classList.remove('rolling', 'blank');
+      el.innerHTML = dieFaceHTML(i === 0 ? v1 : v2);
+    });
+    onResult(v1, v2);
+  }, 450);
+}
+
+function rollHenchDice() {
+  const results = ['D3 of the cheapest henchman type available','1 henchman of any type in the warband list','D3 henchmen of any type in the warband list','D6 henchmen of any type in the warband list'];
+  rollTwoDice('hd1', 'hd2', (v1, v2) => {
+    const r = results[Math.floor(Math.random() * results.length)];
+    document.querySelector('.result-box strong').textContent = `Result (${v1+v2}): ${r}`;
+  });
+}
+
+function rollTradeDice() {
+  const items = [['Wyrdstone Pendulum','30'],['Lucky Charm','10'],['Sword','10'],['Mace','3'],['Shield','5'],['Helmet','10'],['Light Armour','20']];
+  rollTwoDice('td1', 'td2', (v1, v2) => {
+    const item = items[Math.floor(Math.random() * items.length)];
+    document.querySelector('.result-box strong').textContent = `Result (${v1+v2}): ${item[0]} — ${item[1]} gc`;
+  });
+}
+
+function updateDiceCount() {
+  const extra = parseInt(document.getElementById('extra-dice')?.value) || 0;
+  const won = document.getElementById('won')?.checked ? 1 : 0;
+  const total = 2 + won + extra;
+  const el = document.getElementById('dice-total');
+  if (el) el.textContent = total;
+  const tray = document.getElementById('explore-tray');
+  if (tray) {
+    tray.innerHTML = Array(total).fill(0).map(() => `<div class="die blank lockable">?</div>`).join('');
+  }
+}
+
+// Init
+showStep(1);
+</script>
+
+<!-- Dead warrior card demo (shows how dead heroes appear in the roster after the wizard) -->
+<div class="modal-backdrop" style="max-width:440px;">
+  <div class="pgw-header">
+    <span class="pgw-title" style="font-size:0.82rem;color:var(--text-dim);font-family:inherit;font-weight:400;">Demo: dead hero card in roster</span>
+  </div>
+  <div class="pgw-body" style="padding:0.9rem;min-height:unset;">
+    <!-- Normal hero card for comparison -->
+    <p class="text-sm text-dim" style="margin-bottom:0.6rem;">Normal card (active hero):</p>
+    <div style="border:1px solid var(--border);border-radius:var(--radius);padding:0.75rem;margin-bottom:1rem;background:var(--bg-card);">
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.25rem;">
+        <span style="font-weight:700;color:var(--text-bright);">Greta the Bold</span>
+        <span style="font-size:0.72rem;background:var(--bg-dark);border:1px solid var(--border);padding:0.1rem 0.45rem;border-radius:999px;color:var(--text-dim);">Champion</span>
+      </div>
+      <div style="font-size:0.78rem;color:var(--text-dim);">11 XP · 2 equipment · 1 skill</div>
+    </div>
+    <!-- Dead hero card -->
+    <p class="text-sm text-dim" style="margin-bottom:0.6rem;">Dead hero — greyed out, excluded from cap &amp; counts:</p>
+    <div style="border:1px solid var(--danger);border-radius:var(--radius);padding:0.75rem;opacity:0.5;background:var(--bg-dark);">
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:0.25rem;">
+        <span style="font-weight:700;text-decoration:line-through;color:var(--danger);">Karl Hammerfist</span>
+        <span style="font-size:0.72rem;color:var(--danger);font-weight:600;">☠ Dead</span>
+      </div>
+      <div style="font-size:0.78rem;color:var(--text-dim);margin-bottom:0.5rem;">Captain · 23 XP · Not counted in hero cap or warband rating</div>
+      <button class="btn btn-danger btn-sm" onclick="this.closest('div[style]').remove()">Remove from Roster</button>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **Color system**: All hex/rgba replaced with OKLCH perceptually uniform values in both light and dark themes; neutrals tinted toward the amber hue family for subconscious cohesion
- **Typography**: Cinzel → Pirata One (display), system-ui → Alegreya (body); hero warrior names render in display font for a natural typographic hierarchy
- **Banned patterns removed**: `border-left: 3px` stripe on warrior cards gone; replaced with per-type header tints via `color-mix(in oklch, ...)`; roster card `::before` gradient stripe hover replaced with a clean shadow lift
- **Variable cleanup**: `--skill-color`, `--spell-color`, `--treasury-positive/negative` now per-theme variables, eliminating 9 hardcoded dark mode override rules; tier badges and sync indicator use semantic vars
- **Design context**: `.impeccable.md` added with project design brief for future design work

## Test plan

- [ ] Dark mode: verify amber gold accent, body text in Alegreya, section titles in Pirata One
- [ ] Light mode: verify parchment background intact, accent readable on light bg
- [ ] Hero warrior cards: amber-tinted header, name in display font
- [ ] Hired sword cards: blue-tinted header
- [ ] Custom warrior cards: purple-tinted header
- [ ] Henchman cards: neutral header (no tint)
- [ ] Skill/spell/injury tags render in correct semantic colors in both themes
- [ ] Treasury income/expense badges render correctly in both themes
- [ ] Tier overview page: standard badge blue, pro badge amber — both readable in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)