### PR TITLE
feat: searchable grade-grouped warband picker

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1841,6 +1841,184 @@ select.form-control {
   .tier-table th, .tier-table td { padding: 0.4rem 0.5rem; font-size: 0.78rem; }
 }
 
+/* ===== WARBAND PICKER ===== */
+
+.warband-picker {
+  position: relative;
+}
+
+.picker-trigger {
+  width: 100%;
+  padding: 0.6rem 0.8rem;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 0.9rem;
+  font-family: inherit;
+  cursor: pointer;
+  text-align: left;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  transition: border-color var(--transition), box-shadow var(--transition), border-radius var(--transition);
+}
+
+.picker-trigger:hover {
+  border-color: var(--border-hover);
+}
+
+.picker-trigger.open {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-glow);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.picker-trigger-text {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.picker-trigger-text.picker-placeholder {
+  color: var(--text-muted);
+}
+
+.picker-chevron {
+  flex-shrink: 0;
+  font-size: 0.6rem;
+  color: var(--text-dim);
+  transition: transform var(--transition);
+}
+
+.picker-trigger.open .picker-chevron {
+  transform: rotate(180deg);
+}
+
+.picker-panel {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: var(--bg-dark);
+  border: 1px solid var(--accent);
+  border-top: none;
+  border-radius: 0 0 var(--radius) var(--radius);
+  box-shadow: 0 8px 24px var(--shadow);
+  z-index: 300;
+  overflow: hidden;
+}
+
+.picker-panel.open {
+  display: block;
+}
+
+.picker-search-wrap {
+  position: relative;
+  padding: 0.4rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-darkest);
+}
+
+.picker-search-icon {
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+.picker-search {
+  width: 100%;
+  padding: 0.4rem 0.6rem 0.4rem 2rem;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 0.875rem;
+  font-family: inherit;
+  transition: border-color var(--transition);
+}
+
+.picker-search:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.picker-list {
+  max-height: 220px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.picker-list::-webkit-scrollbar { width: 4px; }
+.picker-list::-webkit-scrollbar-track { background: transparent; }
+.picker-list::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+
+.picker-group-header {
+  padding: 0.3rem 0.8rem;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  background: var(--bg-darkest);
+  border-top: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+}
+
+.picker-group-header:first-child {
+  border-top: none;
+}
+
+.picker-item {
+  padding: 0.4rem 0.8rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  transition: background var(--transition), color var(--transition);
+}
+
+.picker-item:hover {
+  background: var(--bg-card-hover);
+  color: var(--accent);
+}
+
+.picker-item.selected {
+  background: var(--accent-glow);
+  color: var(--accent);
+}
+
+.picker-item-source {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.picker-item:hover .picker-item-source,
+.picker-item.selected .picker-item-source {
+  color: var(--accent-dim);
+}
+
+.picker-empty {
+  padding: 0.8rem;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  font-style: italic;
+}
+
 /* ===== DARK MODE OVERRIDES ===== */
 
 /* Smooth theme transition */

--- a/docs/superpowers/specs/2026-04-14-warband-picker-design.md
+++ b/docs/superpowers/specs/2026-04-14-warband-picker-design.md
@@ -1,0 +1,97 @@
+# Warband Picker — Design Spec
+
+**Date:** 2026-04-14
+**Status:** Approved (mockup reviewed and accepted by user)
+
+---
+
+## Problem
+
+The Create Warband modal uses a plain `<select>` with 53 warbands listed in alphabetical order. With no grouping or filtering, finding a specific warband requires scrolling through the entire list.
+
+## Goal
+
+Replace the native `<select>` with a custom combobox: a trigger button that opens a dropdown panel containing a live-search input and a grade-grouped scrollable list.
+
+---
+
+## Design
+
+### Interaction
+
+- The field renders as a styled button showing "— Select Warband —" (placeholder) or the selected warband name.
+- Clicking the button opens a dropdown panel directly below it, visually connected (trigger loses bottom border-radius when open).
+- The panel contains a search input (auto-focused on open) and a scrollable list of warbands grouped by grade.
+- Typing in the search filters warbands by name in real time (case-insensitive substring match).
+- Clicking a warband selects it, populates the trigger text, closes the panel, and fires the existing `onWarbandSelectChange()` logic (lore preview, starting gold).
+- Clicking outside the picker or pressing Escape closes the panel without changing the selection.
+- The selected item is visually highlighted when the panel reopens.
+
+### Grouping
+
+Warbands are grouped by their grade from the data (`_grade` field on each warband file). Grade order: `1a → 1b → 1c`. Group headers display as: **Grade 1a**, **Grade 1b**, **Grade 1c**.
+
+When a search is active, only groups with matching results are shown (empty groups are hidden). If nothing matches, a "No warbands match…" message is shown.
+
+Each item shows the warband name (left) and source string (right, dimmed).
+
+---
+
+## Files Changed
+
+### `js/data.js` — `getAllWarbands()`
+
+Add `grade` to each returned entry so the UI can group without additional lookups:
+
+```js
+// Before
+result.push({ id, name, source });
+
+// After
+result.push({ id, name, source, grade: wf._grade });
+```
+
+Subfactions inherit their parent file's `_grade`.
+
+### `index.html` — create modal
+
+Replace:
+```html
+<select id="create-warband-select" class="form-control" onchange="UI.onWarbandSelectChange()">
+  <option value="">-- Select Warband --</option>
+</select>
+```
+
+With the custom picker shell (trigger button + panel div). The panel's list is populated by JS at modal open time (same timing as the old `select` was populated).
+
+Hidden `<input type="hidden" id="create-warband-select">` keeps the existing `submitCreateRoster()` value-reading logic working with zero changes to that function.
+
+### `js/ui.js`
+
+- **`openCreateModal()`** — replace `select.innerHTML = ...` with a call to a new `_renderWarbandPicker()` helper that builds the grouped list HTML and wires up the trigger/panel.
+- **`_renderWarbandPicker()`** — new private method. Builds group headers + item rows into `#picker-list`. Sets trigger text to placeholder. Resets search input.
+- **`_filterWarbandPicker(query)`** — new private method. Filters the rendered list in-place by showing/hiding items and group headers.
+- **`_selectWarband(id)`** — new private method. Sets the hidden input value, updates trigger text, closes panel, calls `onWarbandSelectChange()`.
+- Picker open/close state managed via a CSS class (`open`) on the trigger and panel — no JS state variable needed beyond the hidden input value.
+
+### `css/style.css`
+
+New block of CSS rules for the picker (appended before the dark-mode overrides section):
+- `.warband-picker` — `position: relative` container
+- `.picker-trigger` — styled like `.form-control` but a `<button>`; chevron icon; `open` modifier removes bottom radius
+- `.picker-panel` — `position: absolute`, `display: none` / `.open { display: block }`, border matching trigger accent colour, `z-index: 300` (above modal overlay's 200)
+- `.picker-search-wrap` / `.picker-search` — search row inside panel
+- `.picker-list` — scrollable list, `max-height: 220px`, thin scrollbar
+- `.picker-group-header` — sticky grade label, dimmed uppercase
+- `.picker-item` — hover + selected states using `--accent` and `--accent-glow`
+- `.picker-empty` — italic no-results message
+
+All colours use existing CSS custom properties — no new variables introduced. Dark mode is handled automatically.
+
+---
+
+## Out of Scope
+
+- Keyboard navigation within the list (arrow up/down) — not in this iteration.
+- Showing a grade explanation tooltip — grade labels are self-descriptive enough.
+- Any changes to the hired sword or custom warrior flows — unaffected.

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Alegreya:ital,wght@0,400;0,700;1,400&family=Pirata+One&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/style.css?v=15">
+  <link rel="stylesheet" href="css/style.css?v=16">
   <script>
     // Apply theme before paint to prevent flash
     (function() {
@@ -308,9 +308,24 @@
         </div>
         <div class="form-group">
           <label>Warband Type</label>
-          <select id="create-warband-select" class="form-control" onchange="UI.onWarbandSelectChange()">
-            <option value="">-- Select Warband --</option>
-          </select>
+          <input type="hidden" id="create-warband-select">
+          <div class="warband-picker" id="warband-picker">
+            <button type="button" class="picker-trigger" id="picker-trigger"
+                    onclick="UI.toggleWarbandPicker()">
+              <span class="picker-trigger-text" id="picker-trigger-text">— Select Warband —</span>
+              <span class="picker-chevron">&#9660;</span>
+            </button>
+            <div class="picker-panel" id="picker-panel">
+              <div class="picker-search-wrap">
+                <span class="picker-search-icon">&#128269;</span>
+                <input type="text" class="picker-search" id="picker-search"
+                       placeholder="Search warbands…"
+                       oninput="UI.filterWarbandPicker(this.value)"
+                       autocomplete="off">
+              </div>
+              <div class="picker-list" id="picker-list"></div>
+            </div>
+          </div>
         </div>
         <div class="form-group">
           <label for="create-starting-gold">Starting Gold (gc)</label>
@@ -485,10 +500,10 @@
   <!-- ===== SCRIPTS ===== -->
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="js/cloud.js?v=10"></script>
-  <script src="js/data.js?v=15"></script>
+  <script src="js/data.js?v=16"></script>
   <script src="js/storage.js?v=8"></script>
   <script src="js/roster.js?v=10"></script>
-  <script src="js/ui.js?v=41"></script>
+  <script src="js/ui.js?v=42"></script>
   <script>
     // Boot the app
     (async function() {

--- a/js/data.js
+++ b/js/data.js
@@ -166,6 +166,7 @@ const DataService = {
   // Returns flat list of picker entries — one per subfaction (or one for non-subfaction warbands).
   // Each entry: { id, name, source, grade }
   getAllWarbands() {
+    if (!this.warbandFiles) return [];
     const result = [];
     for (const wf of this.warbandFiles) {
       const opts = wf.subfactions?.options;

--- a/js/data.js
+++ b/js/data.js
@@ -164,17 +164,17 @@ const DataService = {
   },
 
   // Returns flat list of picker entries — one per subfaction (or one for non-subfaction warbands).
-  // Each entry: { id, name, source }
+  // Each entry: { id, name, source, grade }
   getAllWarbands() {
     const result = [];
     for (const wf of this.warbandFiles) {
       const opts = wf.subfactions?.options;
       if (opts && opts.length > 0) {
         for (const sub of opts) {
-          result.push({ id: this.slugify(sub), name: sub, source: wf.source || '' });
+          result.push({ id: this.slugify(sub), name: sub, source: wf.source || '', grade: wf._grade || '' });
         }
       } else {
-        result.push({ id: wf.id, name: wf.name, source: wf.source || '' });
+        result.push({ id: wf.id, name: wf.name, source: wf.source || '', grade: wf._grade || '' });
       }
     }
     return result;

--- a/js/ui.js
+++ b/js/ui.js
@@ -275,6 +275,7 @@ const UI = {
 
   toggleWarbandPicker() {
     const panel = document.getElementById('picker-panel');
+    if (!panel) return;
     if (panel.classList.contains('open')) {
       this._closeWarbandPicker();
     } else {
@@ -286,6 +287,7 @@ const UI = {
     const trigger = document.getElementById('picker-trigger');
     const panel = document.getElementById('picker-panel');
     const search = document.getElementById('picker-search');
+    if (!trigger || !panel || !search) return;
     trigger.classList.add('open');
     panel.classList.add('open');
     search.value = '';
@@ -298,14 +300,18 @@ const UI = {
   },
 
   _closeWarbandPicker() {
-    document.getElementById('picker-trigger').classList.remove('open');
-    document.getElementById('picker-panel').classList.remove('open');
+    const trigger = document.getElementById('picker-trigger');
+    const panel = document.getElementById('picker-panel');
+    if (!trigger || !panel) return;
+    trigger.classList.remove('open');
+    panel.classList.remove('open');
   },
 
   _renderWarbandPickerList(query) {
     const list = document.getElementById('picker-list');
+    if (!list) return;
     const q = query.trim().toLowerCase();
-    const currentId = document.getElementById('create-warband-select').value;
+    const currentId = document.getElementById('create-warband-select')?.value || '';
     const gradeLabel = { '1a': 'Grade 1a', '1b': 'Grade 1b', '1c': 'Grade 1c' };
     const gradeOrder = ['1a', '1b', '1c'];
 
@@ -327,13 +333,15 @@ const UI = {
       for (const w of sorted) {
         total++;
         const sel = w.id === currentId ? ' selected' : '';
-        html += `<div class="picker-item${sel}" data-id="${this.escAttr(w.id)}"
-                      onclick="UI.selectWarbandItem('${this.escAttr(w.id)}')">${
+        html += `<div class="picker-item${sel}" data-id="${this.escAttr(w.id)}">${
           this.esc(w.name)}<span class="picker-item-source">${this.esc(w.source)}</span></div>`;
       }
     }
     if (total === 0) {
-      html = `<div class="picker-empty">No warbands match &ldquo;${this.esc(query)}&rdquo;</div>`;
+      const trimmedQuery = query.trim();
+      html = trimmedQuery
+        ? `<div class="picker-empty">No warbands match &ldquo;${this.esc(trimmedQuery)}&rdquo;</div>`
+        : `<div class="picker-empty">No warbands available.</div>`;
     }
     list.innerHTML = html;
   },
@@ -344,11 +352,17 @@ const UI = {
 
   selectWarbandItem(id) {
     const w = DataService.getAllWarbands().find(x => x.id === id);
-    if (!w) return;
+    if (!w) {
+      this._closeWarbandPicker();
+      this.toast('Could not select warband — please refresh and try again.', 'error');
+      return;
+    }
     document.getElementById('create-warband-select').value = id;
     const triggerText = document.getElementById('picker-trigger-text');
-    triggerText.textContent = w.name;
-    triggerText.classList.remove('picker-placeholder');
+    if (triggerText) {
+      triggerText.textContent = w.name;
+      triggerText.classList.remove('picker-placeholder');
+    }
     this._closeWarbandPicker();
     this.onWarbandSelectChange();
   },
@@ -368,10 +382,10 @@ const UI = {
       if (goldInput) goldInput.value = startingGc;
       const lore = DataService._stripHtml(warbandFile.lore || warbandFile.warbandRules?.choiceFluff || '')
         .replace(/\s+/g, ' ').trim().slice(0, 300);
-      desc.textContent = lore;
+      if (desc) desc.textContent = lore;
     } else {
       if (goldInput) goldInput.value = '500';
-      desc.textContent = '';
+      if (desc) desc.textContent = '';
     }
   },
 
@@ -2238,13 +2252,23 @@ const UI = {
       });
     });
 
-    // Close warband picker on outside click or Escape
+    // Warband picker: delegated item selection (avoids inline onclick XSS risk)
+    document.getElementById('picker-list').addEventListener('click', (e) => {
+      const item = e.target.closest('.picker-item');
+      if (item) this.selectWarbandItem(item.dataset.id);
+    });
+
+    // Warband picker: close on outside click or Escape
     document.addEventListener('click', (e) => {
+      const panel = document.getElementById('picker-panel');
+      if (!panel?.classList.contains('open')) return;
       const picker = document.getElementById('warband-picker');
       if (picker && !picker.contains(e.target)) this._closeWarbandPicker();
     });
     document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape') this._closeWarbandPicker();
+      if (e.key === 'Escape' && document.getElementById('picker-panel')?.classList.contains('open')) {
+        this._closeWarbandPicker();
+      }
     });
 
     // Close confirm overlay

--- a/js/ui.js
+++ b/js/ui.js
@@ -262,17 +262,95 @@ const UI = {
         return;
       }
     }
-    const modal = document.getElementById('create-modal');
-    const select = document.getElementById('create-warband-select');
-    select.innerHTML = '<option value="">-- Select Warband --</option>' +
-      DataService.getAllWarbands()
-        .sort((a, b) => a.name.localeCompare(b.name))
-        .map(w => `<option value="${w.id}">${this.esc(w.name)} (${this.esc(w.source)})</option>`)
-        .join('');
     document.getElementById('create-roster-name').value = '';
     document.getElementById('create-starting-gold').value = '500';
     document.getElementById('warband-description').textContent = '';
-    modal.classList.add('active');
+    document.getElementById('create-warband-select').value = '';
+    document.getElementById('picker-trigger-text').textContent = '— Select Warband —';
+    document.getElementById('picker-trigger-text').classList.add('picker-placeholder');
+    this._renderWarbandPickerList('');
+    this._closeWarbandPicker();
+    document.getElementById('create-modal').classList.add('active');
+  },
+
+  toggleWarbandPicker() {
+    const panel = document.getElementById('picker-panel');
+    if (panel.classList.contains('open')) {
+      this._closeWarbandPicker();
+    } else {
+      this._openWarbandPicker();
+    }
+  },
+
+  _openWarbandPicker() {
+    const trigger = document.getElementById('picker-trigger');
+    const panel = document.getElementById('picker-panel');
+    const search = document.getElementById('picker-search');
+    trigger.classList.add('open');
+    panel.classList.add('open');
+    search.value = '';
+    this._renderWarbandPickerList('');
+    setTimeout(() => {
+      search.focus();
+      const sel = panel.querySelector('.picker-item.selected');
+      if (sel) sel.scrollIntoView({ block: 'nearest' });
+    }, 20);
+  },
+
+  _closeWarbandPicker() {
+    document.getElementById('picker-trigger').classList.remove('open');
+    document.getElementById('picker-panel').classList.remove('open');
+  },
+
+  _renderWarbandPickerList(query) {
+    const list = document.getElementById('picker-list');
+    const q = query.trim().toLowerCase();
+    const currentId = document.getElementById('create-warband-select').value;
+    const gradeLabel = { '1a': 'Grade 1a', '1b': 'Grade 1b', '1c': 'Grade 1c' };
+    const gradeOrder = ['1a', '1b', '1c'];
+
+    const groups = {};
+    for (const w of DataService.getAllWarbands()) {
+      if (q && !w.name.toLowerCase().includes(q)) continue;
+      const g = w.grade || 'other';
+      if (!groups[g]) groups[g] = [];
+      groups[g].push(w);
+    }
+
+    let html = '';
+    let total = 0;
+    for (const g of gradeOrder) {
+      const items = groups[g];
+      if (!items) continue;
+      const sorted = items.slice().sort((a, b) => a.name.localeCompare(b.name));
+      html += `<div class="picker-group-header">${this.esc(gradeLabel[g] || g)}</div>`;
+      for (const w of sorted) {
+        total++;
+        const sel = w.id === currentId ? ' selected' : '';
+        html += `<div class="picker-item${sel}" data-id="${this.escAttr(w.id)}"
+                      onclick="UI.selectWarbandItem('${this.escAttr(w.id)}')">${
+          this.esc(w.name)}<span class="picker-item-source">${this.esc(w.source)}</span></div>`;
+      }
+    }
+    if (total === 0) {
+      html = `<div class="picker-empty">No warbands match &ldquo;${this.esc(query)}&rdquo;</div>`;
+    }
+    list.innerHTML = html;
+  },
+
+  filterWarbandPicker(query) {
+    this._renderWarbandPickerList(query);
+  },
+
+  selectWarbandItem(id) {
+    const w = DataService.getAllWarbands().find(x => x.id === id);
+    if (!w) return;
+    document.getElementById('create-warband-select').value = id;
+    const triggerText = document.getElementById('picker-trigger-text');
+    triggerText.textContent = w.name;
+    triggerText.classList.remove('picker-placeholder');
+    this._closeWarbandPicker();
+    this.onWarbandSelectChange();
   },
 
   closeCreateModal() {
@@ -2158,6 +2236,15 @@ const UI = {
       overlay.addEventListener('click', (e) => {
         if (e.target === overlay) overlay.classList.remove('active');
       });
+    });
+
+    // Close warband picker on outside click or Escape
+    document.addEventListener('click', (e) => {
+      const picker = document.getElementById('warband-picker');
+      if (picker && !picker.contains(e.target)) this._closeWarbandPicker();
+    });
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') this._closeWarbandPicker();
     });
 
     // Close confirm overlay


### PR DESCRIPTION
## Summary

- Replaces the plain `<select>` in the Create Warband modal with a custom combobox
- Click the field to open a dropdown with a live search bar and warbands grouped by grade (1a / 1b / 1c) with sticky headers
- Selecting a warband closes the panel and fires the existing lore/gold preview — no behaviour changes to create or submit flows
- A hidden `<input id="create-warband-select">` keeps `submitCreateRoster()` and `onWarbandSelectChange()` working without modification
- All colours use existing CSS custom properties; dark and light themes work automatically

## Test plan

- [ ] Open Create Warband modal — field shows placeholder, no list visible
- [ ] Click field — panel opens, search focused, warbands grouped under Grade 1a / 1b / 1c headers
- [ ] Type a partial name (e.g. "dwarf") — list filters live, empty groups hidden
- [ ] Type something with no match — "No warbands match…" message shown
- [ ] Select a warband — trigger shows warband name, lore preview updates, starting gold updates
- [ ] Reopen picker — selected warband is highlighted
- [ ] Click outside or press Escape — panel closes without changing selection
- [ ] Submit form with no warband selected — toast error fires as before
- [ ] Create a valid warband — roster created successfully
- [ ] Check light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)