### PR TITLE
feat: split hired swords out of member count + custom warrior member toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -796,6 +796,17 @@ select.form-control {
   flex-wrap: wrap;
 }
 
+.custom-member-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  padding: 0.25rem 0.45rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+
 /* ===== EXPERIENCE BAR ===== */
 .exp-bar-container {
   margin-top: 0.6rem;

--- a/index.html
+++ b/index.html
@@ -71,6 +71,10 @@
             <div class="value" id="summary-members">0</div>
           </div>
           <div class="summary-stat">
+            <div class="label">Hired Swords</div>
+            <div class="value" id="summary-hired-swords">0</div>
+          </div>
+          <div class="summary-stat">
             <div class="label">Rating</div>
             <div class="value" id="summary-rating">0</div>
           </div>

--- a/js/roster.js
+++ b/js/roster.js
@@ -123,6 +123,7 @@ const RosterModel = {
       ),
       isHero: true,
       isCustom: true,
+      countAsMember: true,
     };
   },
 
@@ -300,9 +301,14 @@ const RosterModel = {
   },
 
   getMemberCount(roster) {
-    let count = this._heroLike(roster).length;
+    const countedCustom = (roster.customWarriors || []).filter(w => w.countAsMember !== false);
+    let count = (roster.heroes || []).length + countedCustom.length;
     for (const hg of roster.henchmen) count += hg.groupSize || 1;
     return count;
+  },
+
+  getHiredSwordCount(roster) {
+    return (roster.hiredSwords || []).length;
   },
 
   addBattle(roster, result, notes) {

--- a/js/ui.js
+++ b/js/ui.js
@@ -435,6 +435,7 @@ const UI = {
       ? (warbandResult.subfaction || warbandResult.warbandFile.name)
       : r.warbandId;
     const memberCount = RosterModel.getMemberCount(r);
+    const hiredSwordCount = RosterModel.getHiredSwordCount(r);
     const rating = RosterModel.calculateWarbandRating(r);
     const totalSpent = RosterModel.calculateTotalCost(r);
 
@@ -444,6 +445,7 @@ const UI = {
 
     // Summary
     document.getElementById('summary-members').textContent = `${memberCount} / ${this.getMaxMembers(r)}`;
+    document.getElementById('summary-hired-swords').textContent = hiredSwordCount;
     document.getElementById('summary-rating').textContent = rating;
     document.getElementById('summary-gold').textContent = r.gold + ' gc';
     document.getElementById('summary-spent').textContent = totalSpent + ' gc';
@@ -709,6 +711,13 @@ const UI = {
               <button class="btn btn-sm" onclick="UI.adjustGroupSize(${index}, -1)">-1 Member</button>
               <button class="btn btn-sm" onclick="UI.openLadsGotTalentModal(${index})">Lad's Got Talent</button>
             ` : ''}
+            ${listType === 'customWarriors' ? `
+              <label class="custom-member-toggle">
+                <input type="checkbox" ${warrior.countAsMember !== false ? 'checked' : ''}
+                  onchange="UI.toggleCustomMemberCount(${index}, this.checked)">
+                Count as Member
+              </label>
+            ` : ''}
             <button class="btn btn-sm btn-danger" onclick="UI.removeWarrior('${listType}', ${index})">Remove</button>
           </div>
         </div>
@@ -801,12 +810,6 @@ const UI = {
     const warrior = RosterModel.createHiredSword(key);
     if (!warrior) return this.toast('Unknown hired sword.', 'error');
 
-    const memberCount = RosterModel.getMemberCount(r);
-    const maxMembers = this.getMaxMembers(r);
-    if (memberCount >= maxMembers) {
-      return this.toast(`Warband is full (${maxMembers} members).`, 'error');
-    }
-
     r.hiredSwords.push(warrior);
     this._logWarriorHire(warrior);
     this.saveCurrentRoster();
@@ -898,6 +901,14 @@ const UI = {
     this.renderRosterEditor();
     document.getElementById('custom-warrior-modal').classList.remove('active');
     this.toast(`${name} created!`, 'success');
+  },
+
+  toggleCustomMemberCount(index, checked) {
+    const warrior = this.currentRoster.customWarriors[index];
+    if (!warrior) return;
+    warrior.countAsMember = checked;
+    this.saveCurrentRoster();
+    this.renderRosterEditor();
   },
 
   // === LAD'S GOT TALENT ===
@@ -2028,6 +2039,7 @@ const UI = {
 
   <div class="summary">
     <div class="summary-item"><div class="label">Members</div><div class="value">${memberCount} / ${this.getMaxMembers(r)}</div></div>
+    <div class="summary-item"><div class="label">Hired Swords</div><div class="value">${RosterModel.getHiredSwordCount(r)}</div></div>
     <div class="summary-item"><div class="label">Rating</div><div class="value">${rating}</div></div>
     <div class="summary-item"><div class="label">Treasury</div><div class="value gold">${r.gold} gc</div></div>
     <div class="summary-item"><div class="label">Wyrdstone</div><div class="value">${r.wyrdstone}</div></div>


### PR DESCRIPTION
## Summary
- Hired swords (and dramatis personae) no longer count toward the **Members** tally; a new **Hired Swords** box appears in the roster editor summary bar and PDF export
- The warband member cap no longer gates hired sword hiring — they are freely hirable
- Custom warriors gain a per-warrior **Count as Member** checkbox; unchecked warriors are excluded from the member count. Defaults to checked (no behaviour change for existing rosters)

## Test Plan
- [ ] Open a roster with hired swords — confirm Members count excludes them and Hired Swords box shows correct count
- [ ] Hire a hired sword on a full warband — confirm it is no longer blocked
- [ ] Create a custom warrior — confirm checkbox is checked by default and warrior appears in Members count
- [ ] Uncheck "Count as Member" on a custom warrior — confirm Members count drops immediately
- [ ] Re-check — confirm Members count recovers
- [ ] Open PDF export — confirm Hired Swords box is present in the summary