### PR TITLE
feat: segmented XP bar with per-level bars and partial fill

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -808,30 +808,55 @@ select.form-control {
 }
 
 /* ===== EXPERIENCE BAR ===== */
-.exp-bar-container {
+.xp-seg-container {
   margin-top: 0.6rem;
 }
 
-.exp-bar-label {
+.xp-seg-row {
   display: flex;
-  justify-content: space-between;
-  font-size: 0.72rem;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.xp-seg-level {
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  background: #2d2550;
+  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.8rem;
+  color: #fff;
+}
+
+.xp-seg-bars {
+  display: flex;
+  flex: 1;
+  gap: 3px;
+}
+
+.xp-seg-bar {
+  height: 10px;
+  flex: 1;
+  border-radius: 3px;
+  border: 1.5px solid var(--accent);
+  background: transparent;
+  opacity: 0.45;
+}
+
+.xp-seg-bar.filled {
+  background: var(--accent);
+  opacity: 1;
+}
+
+.xp-seg-label {
+  font-size: 0.7rem;
   color: var(--text-dim);
-  margin-bottom: 0.2rem;
-}
-
-.exp-bar {
-  height: 6px;
-  background: var(--bg-input);
-  border-radius: 3px;
-  overflow: hidden;
-}
-
-.exp-bar-fill {
-  height: 100%;
-  background: linear-gradient(90deg, var(--accent-dim), var(--accent));
-  border-radius: 3px;
-  transition: width 0.4s ease;
+  margin-top: 0.25rem;
+  padding-left: 34px;
 }
 
 /* ===== TREASURY LEDGER ===== */
@@ -1356,7 +1381,7 @@ select.form-control {
   }
 
   /* Experience bar labels */
-  .exp-bar-label {
+  .xp-seg-label {
     font-size: 0.65rem;
   }
 

--- a/css/style.css
+++ b/css/style.css
@@ -822,7 +822,7 @@ select.form-control {
   flex-shrink: 0;
   width: 26px;
   height: 26px;
-  background: #2d2550;
+  background: var(--accent);
   border-radius: 5px;
   display: flex;
   align-items: center;
@@ -852,11 +852,16 @@ select.form-control {
   opacity: 1;
 }
 
+.xp-seg-bar.partial {
+  background: linear-gradient(90deg, var(--accent) var(--fill), transparent var(--fill));
+  opacity: 1;
+}
+
 .xp-seg-label {
   font-size: 0.7rem;
   color: var(--text-dim);
   margin-top: 0.25rem;
-  padding-left: 34px;
+  padding-left: calc(26px + 0.4rem);
 }
 
 /* ===== TREASURY LEDGER ===== */

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Alegreya:ital,wght@0,400;0,700;1,400&family=Pirata+One&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/style.css?v=16">
+  <link rel="stylesheet" href="css/style.css?v=17">
   <script>
     // Apply theme before paint to prevent flash
     (function() {
@@ -507,7 +507,7 @@
   <script src="js/data.js?v=16"></script>
   <script src="js/storage.js?v=8"></script>
   <script src="js/roster.js?v=10"></script>
-  <script src="js/ui.js?v=43"></script>
+  <script src="js/ui.js?v=44"></script>
   <script>
     // Boot the app
     (async function() {

--- a/js/ui.js
+++ b/js/ui.js
@@ -574,38 +574,47 @@ const UI = {
     }, 0);
     const totalCost = warrior.cost + eqCost;
 
-    // Experience bar for heroes
+    // Experience bar
+    const _xpSegBar = (i, level, prevThreshold, nextThreshold, xp) => {
+      if (i < level) return `<div class="xp-seg-bar filled"></div>`;
+      if (i === level && nextThreshold != null) {
+        const pct = Math.min(((xp - prevThreshold) / (nextThreshold - prevThreshold)) * 100, 100);
+        return `<div class="xp-seg-bar" style="background:linear-gradient(90deg,var(--accent) ${pct}%,transparent ${pct}%);opacity:1"></div>`;
+      }
+      return `<div class="xp-seg-bar"></div>`;
+    };
+
     let expBar = '';
     if (isHero) {
       const level = RosterModel.getHeroLevel(warrior.experience);
+      const thresholds = DataService.advancement.heroAdvancement.expThresholds;
       const nextThreshold = RosterModel.getNextThreshold(warrior.experience);
-      const prevThreshold = level > 0 ? DataService.advancement.heroAdvancement.expThresholds[level - 1] : 0;
-      const progress = nextThreshold > prevThreshold ? ((warrior.experience - prevThreshold) / (nextThreshold - prevThreshold)) * 100 : 100;
+      const prevThreshold = level > 0 ? thresholds[level - 1] : 0;
+      const nextLabel = nextThreshold != null ? `Next level at ${nextThreshold} XP` : 'Max level';
+      const segments = thresholds.map((_, i) => _xpSegBar(i, level, prevThreshold, nextThreshold, warrior.experience)).join('');
       expBar = `
-        <div class="exp-bar-container">
-          <div class="exp-bar-label">
-            <span>EXP: ${warrior.experience} (Level ${level})</span>
-            <span>Next: ${nextThreshold}</span>
+        <div class="xp-seg-container">
+          <div class="xp-seg-row">
+            <div class="xp-seg-level">${level}</div>
+            <div class="xp-seg-bars">${segments}</div>
           </div>
-          <div class="exp-bar"><div class="exp-bar-fill" style="width:${Math.min(progress, 100)}%"></div></div>
+          <div class="xp-seg-label">${warrior.experience} XP &nbsp;·&nbsp; ${nextLabel}</div>
         </div>
       `;
     } else {
       const hLevel = RosterModel.getHenchmanLevel(warrior.experience);
-      const hNext  = RosterModel.getHenchmanNextThreshold(warrior.experience);
       const hThresholds = DataService.advancement?.henchmanAdvancement?.expThresholds || [2, 5, 9, 15];
-      const hPrev  = hLevel > 0 ? hThresholds[hLevel - 1] : 0;
-      const hProgress = hNext != null
-        ? ((warrior.experience - hPrev) / (hNext - hPrev)) * 100
-        : 100; // max level — full bar
-      const hNextLabel = hNext != null ? `Next: ${hNext}` : 'Max level';
+      const hNext = RosterModel.getHenchmanNextThreshold(warrior.experience);
+      const hPrev = hLevel > 0 ? hThresholds[hLevel - 1] : 0;
+      const hNextLabel = hNext != null ? `Next level at ${hNext} XP` : 'Max level';
+      const segments = hThresholds.map((_, i) => _xpSegBar(i, hLevel, hPrev, hNext, warrior.experience)).join('');
       expBar = `
-        <div class="exp-bar-container">
-          <div class="exp-bar-label">
-            <span>EXP: ${warrior.experience} (Level ${hLevel})</span>
-            <span>${hNextLabel} &nbsp;·&nbsp; Group: ${warrior.groupSize || 1}</span>
+        <div class="xp-seg-container">
+          <div class="xp-seg-row">
+            <div class="xp-seg-level">${hLevel}</div>
+            <div class="xp-seg-bars">${segments}</div>
           </div>
-          <div class="exp-bar"><div class="exp-bar-fill" style="width:${Math.min(hProgress, 100)}%"></div></div>
+          <div class="xp-seg-label">${warrior.experience} XP &nbsp;·&nbsp; ${hNextLabel} &nbsp;·&nbsp; Group: ${warrior.groupSize || 1}</div>
         </div>
       `;
     }

--- a/js/ui.js
+++ b/js/ui.js
@@ -567,6 +567,15 @@ const UI = {
     }
   },
 
+  _xpSegBar(i, level, prevThreshold, nextThreshold, xp) {
+    if (i < level) return `<div class="xp-seg-bar filled"></div>`;
+    if (i === level && nextThreshold != null) {
+      const pct = Math.min(((xp - prevThreshold) / (nextThreshold - prevThreshold)) * 100, 100);
+      return `<div class="xp-seg-bar partial" style="--fill:${pct}%"></div>`;
+    }
+    return `<div class="xp-seg-bar"></div>`;
+  },
+
   renderWarriorCard(warrior, index, isHero, listTypeOverride) {
     const eqCost = warrior.equipment.reduce((sum, eq) => {
       const item = DataService.getEquipmentItem(eq.id);
@@ -575,49 +584,28 @@ const UI = {
     const totalCost = warrior.cost + eqCost;
 
     // Experience bar
-    const _xpSegBar = (i, level, prevThreshold, nextThreshold, xp) => {
-      if (i < level) return `<div class="xp-seg-bar filled"></div>`;
-      if (i === level && nextThreshold != null) {
-        const pct = Math.min(((xp - prevThreshold) / (nextThreshold - prevThreshold)) * 100, 100);
-        return `<div class="xp-seg-bar" style="background:linear-gradient(90deg,var(--accent) ${pct}%,transparent ${pct}%);opacity:1"></div>`;
-      }
-      return `<div class="xp-seg-bar"></div>`;
-    };
-
-    let expBar = '';
-    if (isHero) {
-      const level = RosterModel.getHeroLevel(warrior.experience);
-      const thresholds = DataService.advancement.heroAdvancement.expThresholds;
-      const nextThreshold = RosterModel.getNextThreshold(warrior.experience);
-      const prevThreshold = level > 0 ? thresholds[level - 1] : 0;
-      const nextLabel = nextThreshold != null ? `Next level at ${nextThreshold} XP` : 'Max level';
-      const segments = thresholds.map((_, i) => _xpSegBar(i, level, prevThreshold, nextThreshold, warrior.experience)).join('');
-      expBar = `
-        <div class="xp-seg-container">
-          <div class="xp-seg-row">
-            <div class="xp-seg-level">${level}</div>
-            <div class="xp-seg-bars">${segments}</div>
-          </div>
-          <div class="xp-seg-label">${warrior.experience} XP &nbsp;·&nbsp; ${nextLabel}</div>
+    const thresholds = isHero
+      ? DataService.advancement.heroAdvancement.expThresholds
+      : (DataService.advancement?.henchmanAdvancement?.expThresholds || [2, 5, 9, 15]);
+    const level = isHero
+      ? RosterModel.getHeroLevel(warrior.experience)
+      : RosterModel.getHenchmanLevel(warrior.experience);
+    const nextThreshold = isHero
+      ? RosterModel.getNextThreshold(warrior.experience)
+      : RosterModel.getHenchmanNextThreshold(warrior.experience);
+    const prevThreshold = level > 0 ? thresholds[level - 1] : 0;
+    const nextLabel = nextThreshold != null ? `Next level at ${nextThreshold} XP` : 'Max level';
+    const groupSuffix = !isHero ? ` &nbsp;·&nbsp; Group: ${warrior.groupSize || 1}` : '';
+    const segments = thresholds.map((_, i) => this._xpSegBar(i, level, prevThreshold, nextThreshold, warrior.experience)).join('');
+    const expBar = `
+      <div class="xp-seg-container">
+        <div class="xp-seg-row">
+          <div class="xp-seg-level">${level}</div>
+          <div class="xp-seg-bars">${segments}</div>
         </div>
-      `;
-    } else {
-      const hLevel = RosterModel.getHenchmanLevel(warrior.experience);
-      const hThresholds = DataService.advancement?.henchmanAdvancement?.expThresholds || [2, 5, 9, 15];
-      const hNext = RosterModel.getHenchmanNextThreshold(warrior.experience);
-      const hPrev = hLevel > 0 ? hThresholds[hLevel - 1] : 0;
-      const hNextLabel = hNext != null ? `Next level at ${hNext} XP` : 'Max level';
-      const segments = hThresholds.map((_, i) => _xpSegBar(i, hLevel, hPrev, hNext, warrior.experience)).join('');
-      expBar = `
-        <div class="xp-seg-container">
-          <div class="xp-seg-row">
-            <div class="xp-seg-level">${hLevel}</div>
-            <div class="xp-seg-bars">${segments}</div>
-          </div>
-          <div class="xp-seg-label">${warrior.experience} XP &nbsp;·&nbsp; ${hNextLabel} &nbsp;·&nbsp; Group: ${warrior.groupSize || 1}</div>
-        </div>
-      `;
-    }
+        <div class="xp-seg-label">${warrior.experience} XP &nbsp;·&nbsp; ${nextLabel}${groupSuffix}</div>
+      </div>
+    `;
 
     const listType = listTypeOverride || (isHero ? 'heroes' : 'henchmen');
     const cardTypeClass = listTypeOverride === 'hiredSwords' ? 'warrior-card--hired'


### PR DESCRIPTION
## Summary
- Replaces the single progress bar with individual thin segment bars — one per level threshold
- Level number displayed in a dark box to the left of the bars
- Filled bars = completed levels; the current level bar partially fills based on XP progress within that level (hard-stop gradient); empty bars = future levels
- Heroes show 21 segments, henchmen show 4

## Test Plan
- [ ] Open a hero card — confirm 21 segments, correct number filled for their level
- [ ] Open a henchman card — confirm 4 segments, correct number filled
- [ ] Hit +1 XP repeatedly — confirm the current segment fills gradually then the next one lights up
- [ ] Check a max-level warrior — all segments filled, label shows "Max level"
- [ ] Check dark and light mode — bars readable in both themes