### PR TITLE
fix: allow Lad's Got Talent up to the universal 6-hero cap

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -915,8 +915,10 @@ const UI = {
     const { warbandFile, subfaction } = warbandResult || { warbandFile: null, subfaction: null };
     const heroFighters = (warbandFile?.fighters || []).filter(f => f.type === 'hero');
 
-    // Max heroes check
-    const maxHeroes = heroFighters.reduce((sum, h) => sum + (h.maxQty || 0), 0);
+    // Max heroes check — universal cap is 6 (1 leader + 5 others per the rules).
+    // Some warbands list fewer hero types, but any warband can reach 6 via LGT.
+    const warbandMax = heroFighters.reduce((sum, h) => sum + (h.maxQty || 0), 0);
+    const maxHeroes = Math.max(warbandMax, 6);
     if (r.heroes.length >= maxHeroes) {
       return this.toast('Already at max heroes (' + maxHeroes + '). Roll again on the advancement table.', 'error');
     }


### PR DESCRIPTION
## Summary

- The LGT hero cap check was using the sum of warband template `maxQty` values, which totals 5 for Hochland Bandits (and many other warbands)
- Per the rulebook, the universal maximum is always 6 heroes (1 leader + up to 5 others); the warband list limits how many of *each type* you can hire, but LGT can push any warband up to 6
- Fix: `Math.max(warbandMax, 6)` ensures the LGT cap is always at least 6

Fixes #103

## Test plan
- [ ] Open a Hochland Bandits roster with 5 heroes — Lad's Got Talent should now work
- [ ] Open any warband at 6 heroes — Lad's Got Talent should be blocked with "Already at max heroes (6)"
- [ ] Warbands that already have 6+ defined hero types (Skaven, Bretonnians, etc.) should be unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)